### PR TITLE
Add MCP Ping Support with Test Infrastructure Improvements

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -48,7 +48,10 @@ pub async fn handle_tool_call(
     tool_name: &str,
     args: Value,
 ) -> Result<ToolResult> {
-    server.ensure_client_started().await?;
+    // set_workspace manages the client lifecycle itself, so skip eager client start.
+    if tool_name != "rust_analyzer_set_workspace" {
+        server.ensure_client_started().await?;
+    }
 
     match tool_name {
         "rust_analyzer_hover" => handle_hover(server, args).await,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -158,6 +158,11 @@ impl RustAnalyzerMCPServer {
                     }
                 }),
             },
+            "ping" => MCPResponse::Success {
+                jsonrpc: "2.0".to_string(),
+                id: request.id,
+                result: json!({}),
+            },
             "tools/list" => MCPResponse::Success {
                 jsonrpc: "2.0".to_string(),
                 id: request.id,

--- a/test-support/src/ipc/client.rs
+++ b/test-support/src/ipc/client.rs
@@ -38,6 +38,11 @@ impl IpcClient {
             _ => return Err(anyhow::anyhow!("Unknown project type: {}", project_type)),
         };
 
+        // Canonicalize the workspace path to ensure it's absolute
+        let workspace_path = workspace_path
+            .canonicalize()
+            .unwrap_or_else(|_| workspace_path.clone());
+
         let sock_path = socket_path(project_type);
 
         // Try to connect to existing server

--- a/test-support/src/ipc/server.rs
+++ b/test-support/src/ipc/server.rs
@@ -124,6 +124,9 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
                 // Update last activity
                 *last_activity.lock().unwrap() = Instant::now();
 
+                // Set stream to blocking mode (listener is non-blocking for shutdown checks)
+                stream.set_nonblocking(false)?;
+
                 // Handle client connection
                 let mut stream_reader = BufReader::new(stream.try_clone()?);
 

--- a/test-support/src/ipc/server.rs
+++ b/test-support/src/ipc/server.rs
@@ -271,7 +271,14 @@ fn wait_for_ready(
 }
 
 pub fn socket_path(project_type: &str) -> PathBuf {
-    let socket_dir = std::env::temp_dir().join("rust-analyzer-mcp-sockets");
+    let socket_dir = std::env::temp_dir().join("ra-mcp");
     let _ = fs::create_dir_all(&socket_dir);
-    socket_dir.join(format!("{}.sock", project_type))
+    // Use shorter names to avoid SUN_LEN limit (104 bytes on macOS)
+    let socket_name = match project_type {
+        "test-project-diagnostics" => "diag.sock",
+        "test-project-concurrent" => "conc.sock",
+        "test-project-singleton" => "sing.sock",
+        _ => "main.sock",
+    };
+    socket_dir.join(socket_name)
 }


### PR DESCRIPTION
Implements the MCP `ping` utility method as specified in the [Model Context Protocol specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/utilities/ping), along with fixes to the test infrastructure that improve reliability across the test suite.

### Implementation Details

#### Ping Handler
- Added `ping` method handler in `src/mcp/server.rs`
- Returns empty object `{}` per MCP specification requirements
- Stateless, synchronous operation with no parameters
- Enables clients to verify server responsiveness and measure round-trip latency

#### Test Infrastructure Fixes

**Socket Blocking Mode Fix:**
Fixed a critical issue in the test IPC server where accepted connections inherited non-blocking mode from the listener socket, causing spurious `EAGAIN`/`EWOULDBLOCK` errors during request processing.

*Root Cause:*
- The listener socket uses non-blocking mode to enable graceful shutdown (checking `should_shutdown` between `accept()` calls without blocking indefinitely)
- On Unix systems, `accept()` returns connected sockets that inherit the listener's non-blocking flag (POSIX behavior)
- When the server attempts to read requests via `BufReader::read_line()`, non-blocking mode causes reads to fail with `WouldBlock` if data isn't immediately available in the kernel buffer
- This manifested as intermittent failures on sequential requests, where timing variations in pipe/socket buffering would cause reads to fail even though data was in transit

*Solution:*
Explicitly set accepted connections to blocking mode with `stream.set_nonblocking(false)` immediately after `accept()`. This allows the listener to remain non-blocking for shutdown responsiveness while ensuring connected sockets reliably wait for complete request data.

**Additional Infrastructure Improvements:**
- **Path Canonicalization**: Added workspace path canonicalization in `test-support/src/ipc/client.rs` to ensure consistent absolute path handling
- **Unix Socket Path Length**: Shortened socket paths to comply with SUN_LEN limits (104 bytes on macOS) by using abbreviated names
- **Timeout Support**: Added configurable timeout to `IpcClient::send_request` for better failure detection

#### Test Coverage

**Integration Tests** (`tests/integration/mcp_server_test.rs`):
- Response format validation
- Idempotency verification (5 sequential pings)
- Rapid-fire throughput testing (10 sequential pings)
- Post-ping server responsiveness verification

**Stress Tests** (`tests/stress/concurrent_requests.rs`):
- `test_ping_rapid_fire`: Sequential throughput (100-500 requests)
- `test_ping_concurrent`: Concurrent request handling (10-50 parallel)
- `test_ping_interleaved_with_tools`: Ping/tool call alternation (20-50 iterations)
- `test_ping_mixed_concurrent_workload`: Mixed concurrent workload with 40% ping ratio (15-30 concurrent)
- `test_ping_burst_pattern`: Sustained burst patterns (5-10 bursts of 20-50 requests)
- `test_ping_connection_stability`: Connection lifecycle testing (50-100 iterations)

All tests include CI-specific tuning with reduced iteration counts for GitHub Actions environment.