### PR TITLE
Fix request handler for notifications

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -126,11 +126,15 @@ impl RustAnalyzerMCPServer {
             };
 
             debug!("Received request: {}", request.method);
-            let response = self.handle_request(request).await;
-            let response_json = serde_json::to_string(&response)?;
-            writer.write_all(response_json.as_bytes()).await?;
-            writer.write_all(b"\n").await?;
-            writer.flush().await?;
+
+            // requests without an id are notifications and must not receive a response!
+            if request.id.is_some() {
+                let response = self.handle_request(request).await;
+                let response_json = serde_json::to_string(&response)?;
+                writer.write_all(response_json.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await?;
+            }
         }
 
         // Cleanup.
@@ -143,6 +147,7 @@ impl RustAnalyzerMCPServer {
     }
 
     async fn handle_request(&mut self, request: MCPRequest) -> MCPResponse {
+        log::debug!("{request:#?}");
         match request.method.as_str() {
             "initialize" => MCPResponse::Success {
                 jsonrpc: "2.0".to_string(),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -126,6 +126,7 @@ impl RustAnalyzerMCPServer {
             };
 
             debug!("Received request: {}", request.method);
+            log::debug!("{request:#?}");
 
             // requests without an id are notifications and must not receive a response!
             if request.id.is_some() {
@@ -147,7 +148,6 @@ impl RustAnalyzerMCPServer {
     }
 
     async fn handle_request(&mut self, request: MCPRequest) -> MCPResponse {
-        log::debug!("{request:#?}");
         match request.method.as_str() {
             "initialize" => MCPResponse::Success {
                 jsonrpc: "2.0".to_string(),


### PR DESCRIPTION
json rpc notifications are sent without a request id and must not be
responded to. This fix updates the logic to simply accept notifications
without generating a response. Sending a response can lead to crashes
within mcp clients and render the mcp server unusable