### PR TITLE
Fix/skip eager client start on set workspace

### DIFF
--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -48,7 +48,10 @@ pub async fn handle_tool_call(
     tool_name: &str,
     args: Value,
 ) -> Result<ToolResult> {
-    server.ensure_client_started().await?;
+    // set_workspace manages the client lifecycle itself, so skip eager client start.
+    if tool_name != "rust_analyzer_set_workspace" {
+        server.ensure_client_started().await?;
+    }
 
     match tool_name {
         "rust_analyzer_hover" => handle_hover(server, args).await,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -158,6 +158,11 @@ impl RustAnalyzerMCPServer {
                     }
                 }),
             },
+            "ping" => MCPResponse::Success {
+                jsonrpc: "2.0".to_string(),
+                id: request.id,
+                result: json!({}),
+            },
             "tools/list" => MCPResponse::Success {
                 jsonrpc: "2.0".to_string(),
                 id: request.id,

--- a/test-support/src/ipc/client.rs
+++ b/test-support/src/ipc/client.rs
@@ -38,6 +38,11 @@ impl IpcClient {
             _ => return Err(anyhow::anyhow!("Unknown project type: {}", project_type)),
         };
 
+        // Canonicalize the workspace path to ensure it's absolute
+        let workspace_path = workspace_path
+            .canonicalize()
+            .unwrap_or_else(|_| workspace_path.clone());
+
         let sock_path = socket_path(project_type);
 
         // Try to connect to existing server

--- a/test-support/src/ipc/server.rs
+++ b/test-support/src/ipc/server.rs
@@ -124,6 +124,9 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
                 // Update last activity
                 *last_activity.lock().unwrap() = Instant::now();
 
+                // Set stream to blocking mode (listener is non-blocking for shutdown checks)
+                stream.set_nonblocking(false)?;
+
                 // Handle client connection
                 let mut stream_reader = BufReader::new(stream.try_clone()?);
 

--- a/test-support/src/ipc/server.rs
+++ b/test-support/src/ipc/server.rs
@@ -271,7 +271,14 @@ fn wait_for_ready(
 }
 
 pub fn socket_path(project_type: &str) -> PathBuf {
-    let socket_dir = std::env::temp_dir().join("rust-analyzer-mcp-sockets");
+    let socket_dir = std::env::temp_dir().join("ra-mcp");
     let _ = fs::create_dir_all(&socket_dir);
-    socket_dir.join(format!("{}.sock", project_type))
+    // Use shorter names to avoid SUN_LEN limit (104 bytes on macOS)
+    let socket_name = match project_type {
+        "test-project-diagnostics" => "diag.sock",
+        "test-project-concurrent" => "conc.sock",
+        "test-project-singleton" => "sing.sock",
+        _ => "main.sock",
+    };
+    socket_dir.join(socket_name)
 }


### PR DESCRIPTION
When set_workspace was called as the first tool invocation,  ensure_client_started() would spawn rust-analyzer with the default workspace root (often '/') before set_workspace had a chance to update the path.  
This caused rust-analyzer to attempt indexing the entire filesystem, leading to inevitable timeouts on large projects.  
Skip the eager client start for set_workspace since it manages the client lifecycle itself (shutdown old client, update path, start new)