### PR TITLE
fix(mcp): ignore JSON-RPC notifications without id (so can working with codex)

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -126,6 +126,13 @@ impl RustAnalyzerMCPServer {
             };
 
             debug!("Received request: {}", request.method);
+
+            // Notifications do not have `id` and must not receive a JSON-RPC response.
+            if request.id.is_none() {
+                debug!("Ignoring notification without id: {}", request.method);
+                continue;
+            }
+
             let response = self.handle_request(request).await;
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;


### PR DESCRIPTION
  ## Summary
  This change makes the MCP server ignore JSON-RPC notifications (requests without `id`) instead of replying with an
  error.

  ## Why
  Some MCP clients send notification messages such as `notifications/initialized` during handshake.
  Per JSON-RPC semantics, notifications must not receive responses. Returning an error response can cause client
  transport/session startup failures.

  ## Change
  - In the MCP request loop, skip response writing when `request.id.is_none()`.
  - Keep existing request/response behavior unchanged for normal requests with `id`.

  ## Validation
  - Built and ran the patched server.
  - Verified `initialize` + `tools/list` still work.
  - Verified notification messages no longer generate error responses.
  - Tested in codex