### PR TITLE
fix: make rust-analyzer-mcp usable on Windows Codex environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,9 @@ dependencies = [
  "test-support",
  "tokio",
  "tokio-test",
+ "url",
  "which",
+ "winreg",
  "wiremock",
 ]
 
@@ -2467,6 +2469,15 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -2481,6 +2492,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2518,6 +2544,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2530,6 +2562,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2539,6 +2577,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2566,6 +2610,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2575,6 +2625,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2590,6 +2646,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2599,6 +2661,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2619,6 +2687,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ env_logger = "0.10"
 log = "0.4"
 futures = "0.3"
 which = "6.0"
+url = "2.5"
+
+[target.'cfg(windows)'.dependencies]
+winreg = "0.52"
 
 [dev-dependencies]
 # Test support library

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -1,10 +1,11 @@
 use anyhow::{anyhow, Result};
-use log::info;
+use log::{info, warn};
 use serde_json::{json, Value};
 use std::{
     collections::{HashMap, HashSet},
-    path::PathBuf,
-    process::Stdio,
+    fs,
+    path::{Path, PathBuf},
+    process::{Command as StdCommand, Stdio},
     sync::Arc,
     time::Duration,
 };
@@ -15,9 +16,33 @@ use tokio::{
 };
 
 use crate::{
-    config::{DOCUMENT_OPEN_DELAY_MILLIS, LSP_REQUEST_TIMEOUT_SECS},
+    config::{lsp_request_timeout_secs, DOCUMENT_OPEN_DELAY_MILLIS, RUST_ANALYZER_PATH_ENV},
     protocol::lsp::LSPRequest,
 };
+use url::Url;
+
+fn to_file_uri(path: &Path) -> Result<String> {
+    #[cfg(windows)]
+    let normalized = {
+        let path_str = path.to_string_lossy();
+        if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
+            PathBuf::from(stripped)
+        } else {
+            path.to_path_buf()
+        }
+    };
+    #[cfg(not(windows))]
+    let normalized = path.to_path_buf();
+
+    Url::from_file_path(&normalized)
+        .map_err(|_| {
+            anyhow!(
+                "Failed to convert path to file URI: {}",
+                normalized.display()
+            )
+        })
+        .map(|u| u.to_string())
+}
 
 pub struct RustAnalyzerClient {
     pub(super) process: Option<Child>,
@@ -73,6 +98,36 @@ impl RustAnalyzerClient {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+
+        #[cfg(windows)]
+        {
+            // Windows 下某些 MCP 客户端会裁剪 HOME/USERPROFILE，导致 rust-analyzer 初始化卡死。
+            let profile_for_child = std::env::var("USERPROFILE")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .or_else(resolve_windows_user_profile_from_registry);
+
+            if std::env::var("USERPROFILE").is_err() {
+                if let Some(profile) = &profile_for_child {
+                    cmd.env("USERPROFILE", profile);
+                }
+            }
+            if std::env::var("HOME").is_err() {
+                if let Some(profile) = &profile_for_child {
+                    cmd.env("HOME", profile);
+                }
+            }
+            if std::env::var("CARGO_HOME").is_err() {
+                if let Some(cargo_home) = collect_registry_cargo_homes().into_iter().next() {
+                    cmd.env("CARGO_HOME", cargo_home);
+                }
+            }
+            if std::env::var("RUSTUP_HOME").is_err() {
+                if let Some(rustup_home) = collect_registry_rustup_homes().into_iter().next() {
+                    cmd.env("RUSTUP_HOME", rustup_home);
+                }
+            }
+        }
 
         // Pass through isolation environment variables if they're set.
         if let Ok(cache_home) = std::env::var("XDG_CACHE_HOME") {
@@ -185,28 +240,73 @@ impl RustAnalyzerClient {
 
         info!("Sending LSP request: {} with params: {:?}", method, params);
 
-        let Some(stdin) = &mut self.stdin else {
-            return Err(anyhow!("No stdin available"));
-        };
-
-        stdin.write_all(message.as_bytes()).await?;
-        stdin.flush().await?;
-
         // Set up response channel.
         let (tx, rx) = oneshot::channel();
+        // 先注册 pending，再写请求，避免极快响应导致竞态丢包。
         self.pending_requests.lock().await.insert(id, tx);
 
+        if let Some(stdin) = &mut self.stdin {
+            if let Err(e) = stdin.write_all(message.as_bytes()).await {
+                // 写失败时同步清理 pending，避免后续请求被污染。
+                self.pending_requests.lock().await.remove(&id);
+                return Err(anyhow!(
+                    "Failed to write LSP request '{}' (id={}): {}",
+                    method,
+                    id,
+                    e
+                ));
+            }
+            if let Err(e) = stdin.flush().await {
+                self.pending_requests.lock().await.remove(&id);
+                return Err(anyhow!(
+                    "Failed to flush LSP request '{}' (id={}): {}",
+                    method,
+                    id,
+                    e
+                ));
+            }
+        } else {
+            self.pending_requests.lock().await.remove(&id);
+            return Err(anyhow!("No stdin available"));
+        }
         // Wait for response with timeout.
-        tokio::time::timeout(Duration::from_secs(LSP_REQUEST_TIMEOUT_SECS), rx)
-            .await
-            .map_err(|_| anyhow!("Request timeout"))?
-            .map_err(|_| anyhow!("Request cancelled"))
+        match tokio::time::timeout(Duration::from_secs(lsp_request_timeout_secs()), rx).await {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(_)) => {
+                self.pending_requests.lock().await.remove(&id);
+                Err(anyhow!(
+                    "LSP request '{}' (id={}) cancelled before response",
+                    method,
+                    id
+                ))
+            }
+            Err(_) => {
+                self.pending_requests.lock().await.remove(&id);
+                let process_status = if let Some(process) = &mut self.process {
+                    match process.try_wait() {
+                        Ok(Some(status)) => format!("rust-analyzer exited: {}", status),
+                        Ok(None) => "rust-analyzer still running".to_string(),
+                        Err(e) => format!("rust-analyzer status unavailable: {}", e),
+                    }
+                } else {
+                    "rust-analyzer process missing".to_string()
+                };
+                Err(anyhow!(
+                    "LSP request '{}' (id={}) timed out after {}s ({})",
+                    method,
+                    id,
+                    lsp_request_timeout_secs(),
+                    process_status
+                ))
+            }
+        }
     }
 
     async fn initialize(&mut self) -> Result<()> {
+        let root_uri = to_file_uri(&self.workspace_root)?;
         let init_params = json!({
             "processId": std::process::id(),
-            "rootUri": format!("file://{}", self.workspace_root.display()),
+            "rootUri": root_uri,
             "initializationOptions": {
                 "cargo": {
                     "buildScripts": {
@@ -280,11 +380,6 @@ impl RustAnalyzerClient {
         self.send_request("initialize", Some(init_params)).await?;
         self.send_notification("initialized", Some(json!({})))
             .await?;
-
-        // Request workspace reload to trigger cargo check.
-        self.send_request("rust-analyzer/reloadWorkspace", None)
-            .await
-            .ok();
 
         Ok(())
     }
@@ -360,20 +455,288 @@ impl RustAnalyzerClient {
 }
 
 fn find_rust_analyzer() -> Result<PathBuf> {
-    which::which("rust-analyzer").or_else(|_| {
-        // Try common installation locations if not in PATH.
-        let home = std::env::var("HOME").unwrap_or_else(|_| String::from("~"));
-        let cargo_bin = PathBuf::from(home).join(".cargo/bin/rust-analyzer");
-        if cargo_bin.exists() {
-            Ok(cargo_bin)
-        } else {
-            which::which("rust-analyzer")
+    if let Ok(path) = std::env::var(RUST_ANALYZER_PATH_ENV) {
+        let candidate = PathBuf::from(path);
+        if candidate.exists() {
+            return Ok(candidate);
         }
-    })
-    .map_err(|e| {
-        anyhow!(
-            "Failed to find rust-analyzer in PATH or ~/.cargo/bin: {}. Please ensure rust-analyzer is installed.",
-            e
-        )
-    })
+        warn!(
+            "{} is set but points to a missing path: {}",
+            RUST_ANALYZER_PATH_ENV,
+            candidate.display()
+        );
+    }
+
+    if let Ok(found) = which::which("rust-analyzer") {
+        return Ok(found);
+    }
+
+    let candidates = collect_rust_analyzer_candidates();
+    for candidate in &candidates {
+        if candidate.is_file() {
+            info!(
+                "Found rust-analyzer via fallback path: {}",
+                candidate.display()
+            );
+            return Ok(candidate.to_path_buf());
+        }
+    }
+
+    if let Some(via_rustup) = resolve_rust_analyzer_via_rustup() {
+        info!(
+            "Found rust-analyzer via rustup resolution: {}",
+            via_rustup.display()
+        );
+        return Ok(via_rustup);
+    }
+
+    let searched_preview = candidates
+        .iter()
+        .take(8)
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Err(anyhow!(
+        "Failed to find rust-analyzer. Checked PATH, {}, registry-backed candidates, and rustup. Sample searched paths: [{}]. Please set {} explicitly.",
+        RUST_ANALYZER_PATH_ENV,
+        searched_preview,
+        RUST_ANALYZER_PATH_ENV
+    ))
+}
+
+fn collect_rust_analyzer_candidates() -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    #[cfg(windows)]
+    let executable_name = "rust-analyzer.exe";
+    #[cfg(not(windows))]
+    let executable_name = "rust-analyzer";
+
+    let mut home_roots: Vec<PathBuf> = Vec::new();
+
+    if let Ok(cargo_home) = std::env::var("CARGO_HOME") {
+        push_unique_path(&mut home_roots, PathBuf::from(cargo_home));
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        push_unique_path(&mut home_roots, PathBuf::from(home).join(".cargo"));
+    }
+    if let Ok(user_profile) = std::env::var("USERPROFILE") {
+        push_unique_path(&mut home_roots, PathBuf::from(&user_profile).join(".cargo"));
+    }
+    if let (Ok(home_drive), Ok(home_path)) = (std::env::var("HOMEDRIVE"), std::env::var("HOMEPATH"))
+    {
+        push_unique_path(
+            &mut home_roots,
+            PathBuf::from(format!("{}{}", home_drive, home_path)).join(".cargo"),
+        );
+    }
+    #[cfg(windows)]
+    {
+        for cargo_home in collect_registry_cargo_homes() {
+            push_unique_path(&mut home_roots, cargo_home);
+        }
+    }
+
+    for cargo_home in home_roots {
+        push_unique_path(
+            &mut candidates,
+            cargo_home.join("bin").join(executable_name),
+        );
+    }
+
+    let mut rustup_homes: Vec<PathBuf> = Vec::new();
+    if let Ok(rustup_home) = std::env::var("RUSTUP_HOME") {
+        push_unique_path(&mut rustup_homes, PathBuf::from(rustup_home));
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        push_unique_path(&mut rustup_homes, PathBuf::from(home).join(".rustup"));
+    }
+    if let Ok(user_profile) = std::env::var("USERPROFILE") {
+        push_unique_path(
+            &mut rustup_homes,
+            PathBuf::from(user_profile).join(".rustup"),
+        );
+    }
+    if let (Ok(home_drive), Ok(home_path)) = (std::env::var("HOMEDRIVE"), std::env::var("HOMEPATH"))
+    {
+        push_unique_path(
+            &mut rustup_homes,
+            PathBuf::from(format!("{}{}", home_drive, home_path)).join(".rustup"),
+        );
+    }
+    #[cfg(windows)]
+    {
+        for rustup_home in collect_registry_rustup_homes() {
+            push_unique_path(&mut rustup_homes, rustup_home);
+        }
+    }
+
+    for rustup_home in rustup_homes {
+        let toolchains_dir = rustup_home.join("toolchains");
+        let Ok(entries) = fs::read_dir(&toolchains_dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            push_unique_path(
+                &mut candidates,
+                entry.path().join("bin").join(executable_name),
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
+        push_unique_path(
+            &mut candidates,
+            PathBuf::from(local_app_data)
+                .join("Programs")
+                .join("Rust Analyzer")
+                .join(executable_name),
+        );
+    }
+
+    candidates
+}
+
+fn push_unique_path(target: &mut Vec<PathBuf>, candidate: PathBuf) {
+    if !target.iter().any(|existing| existing == &candidate) {
+        target.push(candidate);
+    }
+}
+
+fn resolve_rust_analyzer_via_rustup() -> Option<PathBuf> {
+    for rustup_binary in collect_rustup_binary_candidates() {
+        if !rustup_binary.is_file() {
+            continue;
+        }
+
+        let output = StdCommand::new(&rustup_binary)
+            .args(["which", "rust-analyzer"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            continue;
+        }
+
+        let output_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if output_path.is_empty() {
+            continue;
+        }
+
+        let resolved_path = PathBuf::from(output_path);
+        if resolved_path.is_file() {
+            return Some(resolved_path);
+        }
+    }
+    None
+}
+
+fn collect_rustup_binary_candidates() -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    #[cfg(windows)]
+    let rustup_name = "rustup.exe";
+    #[cfg(not(windows))]
+    let rustup_name = "rustup";
+
+    if let Ok(found) = which::which("rustup") {
+        push_unique_path(&mut candidates, found);
+    }
+
+    if let Ok(cargo_home) = std::env::var("CARGO_HOME") {
+        push_unique_path(
+            &mut candidates,
+            PathBuf::from(cargo_home).join("bin").join(rustup_name),
+        );
+    }
+    if let Ok(user_profile) = std::env::var("USERPROFILE") {
+        push_unique_path(
+            &mut candidates,
+            PathBuf::from(user_profile)
+                .join(".cargo")
+                .join("bin")
+                .join(rustup_name),
+        );
+    }
+    if let (Ok(home_drive), Ok(home_path)) = (std::env::var("HOMEDRIVE"), std::env::var("HOMEPATH"))
+    {
+        push_unique_path(
+            &mut candidates,
+            PathBuf::from(format!("{}{}", home_drive, home_path))
+                .join(".cargo")
+                .join("bin")
+                .join(rustup_name),
+        );
+    }
+    #[cfg(windows)]
+    {
+        for cargo_home in collect_registry_cargo_homes() {
+            push_unique_path(&mut candidates, cargo_home.join("bin").join(rustup_name));
+        }
+    }
+
+    candidates
+}
+
+#[cfg(windows)]
+fn collect_registry_cargo_homes() -> Vec<PathBuf> {
+    collect_registry_homes("CARGO_HOME", ".cargo")
+}
+
+#[cfg(windows)]
+fn collect_registry_rustup_homes() -> Vec<PathBuf> {
+    collect_registry_homes("RUSTUP_HOME", ".rustup")
+}
+
+#[cfg(windows)]
+fn collect_registry_homes(key: &str, fallback_suffix: &str) -> Vec<PathBuf> {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    let mut homes: Vec<PathBuf> = Vec::new();
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+
+    if let Ok(env_key) = hkcu.open_subkey("Environment") {
+        if let Ok(value) = env_key.get_value::<String, _>(key) {
+            push_unique_path(&mut homes, PathBuf::from(value));
+        }
+    }
+
+    if let Ok(volatile_key) = hkcu.open_subkey("Volatile Environment") {
+        if let Ok(user_profile) = volatile_key.get_value::<String, _>("USERPROFILE") {
+            push_unique_path(
+                &mut homes,
+                PathBuf::from(user_profile).join(fallback_suffix),
+            );
+        }
+    }
+
+    homes
+}
+
+#[cfg(windows)]
+fn resolve_windows_user_profile_from_registry() -> Option<String> {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+
+    if let Ok(volatile_key) = hkcu.open_subkey("Volatile Environment") {
+        if let Ok(profile) = volatile_key.get_value::<String, _>("USERPROFILE") {
+            if !profile.trim().is_empty() {
+                return Some(profile);
+            }
+        }
+    }
+
+    if let Ok(env_key) = hkcu.open_subkey("Environment") {
+        if let Ok(profile) = env_key.get_value::<String, _>("USERPROFILE") {
+            if !profile.trim().is_empty() {
+                return Some(profile);
+            }
+        }
+    }
+
+    None
 }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -48,7 +48,12 @@ pub async fn handle_tool_call(
     tool_name: &str,
     args: Value,
 ) -> Result<ToolResult> {
-    server.ensure_client_started().await?;
+    // `set_workspace` should be able to switch root before the first RA startup.
+    // Otherwise the initial startup may happen in an unrelated large cwd and timeout.
+    if tool_name != "rust_analyzer_set_workspace" {
+        server.adjust_workspace_from_file_arg(&args);
+        server.ensure_client_started().await?;
+    }
 
     match tool_name {
         "rust_analyzer_hover" => handle_hover(server, args).await,
@@ -237,13 +242,13 @@ async fn handle_set_workspace(
         }
     });
 
-    // Start the new client automatically.
-    server.ensure_client_started().await?;
-
     Ok(ToolResult {
         content: vec![ContentItem {
             content_type: "text".to_string(),
-            text: format!("Workspace set to: {}", server.workspace_root.display()),
+            text: format!(
+                "Workspace set to: {} (rust-analyzer client will start lazily on next tool call)",
+                server.workspace_root.display()
+            ),
         }],
     })
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,13 +1,18 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use log::{debug, error, info};
-use serde_json::json;
-use std::{path::PathBuf, sync::Arc};
+use serde_json::{json, Value};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter},
     sync::Mutex,
 };
+use url::Url;
 
 use crate::{
+    config::WORKSPACE_ROOT_ENV,
     lsp::RustAnalyzerClient,
     protocol::mcp::{MCPError, MCPRequest, MCPResponse},
 };
@@ -17,6 +22,12 @@ pub struct RustAnalyzerMCPServer {
     pub(super) workspace_root: PathBuf,
 }
 
+#[derive(Clone, Copy)]
+enum TransportMode {
+    JsonLine,
+    ContentLength,
+}
+
 impl Default for RustAnalyzerMCPServer {
     fn default() -> Self {
         Self::new()
@@ -24,10 +35,44 @@ impl Default for RustAnalyzerMCPServer {
 }
 
 impl RustAnalyzerMCPServer {
+    fn resolve_workspace_root() -> PathBuf {
+        if let Ok(workspace) = std::env::var(WORKSPACE_ROOT_ENV) {
+            let workspace_path = PathBuf::from(workspace);
+            return workspace_path
+                .canonicalize()
+                .unwrap_or_else(|_| workspace_path);
+        }
+
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    }
+
+    fn to_file_uri(path: &Path) -> Result<String> {
+        #[cfg(windows)]
+        let normalized = {
+            let path_str = path.to_string_lossy();
+            if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
+                PathBuf::from(stripped)
+            } else {
+                path.to_path_buf()
+            }
+        };
+        #[cfg(not(windows))]
+        let normalized = path.to_path_buf();
+
+        Url::from_file_path(&normalized)
+            .map_err(|_| {
+                anyhow!(
+                    "Failed to convert path to file URI: {}",
+                    normalized.display()
+                )
+            })
+            .map(|u| u.to_string())
+    }
+
     pub fn new() -> Self {
         Self {
             client: None,
-            workspace_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            workspace_root: Self::resolve_workspace_root(),
         }
     }
 
@@ -59,13 +104,46 @@ impl RustAnalyzerMCPServer {
         Ok(())
     }
 
+    /// 在首次启动 rust-analyzer 之前，根据工具参数中的 file_path 自动纠正 workspace。
+    /// 这样可以避免 MCP 进程 cwd 与真实 Rust 工程不一致时导致的初始化异常或超时。
+    pub(super) fn adjust_workspace_from_file_arg(&mut self, args: &Value) {
+        if self.client.is_some() {
+            return;
+        }
+
+        let Some(file_path) = args.get("file_path").and_then(|v| v.as_str()) else {
+            return;
+        };
+        let requested_path = self.resolve_requested_path(file_path);
+        let Some(workspace_root) = find_workspace_root_for_file(&requested_path) else {
+            return;
+        };
+
+        if workspace_root != self.workspace_root {
+            info!(
+                "Adjusting workspace root from '{}' to '{}' based on file_path '{}'",
+                self.workspace_root.display(),
+                workspace_root.display(),
+                requested_path.display()
+            );
+            self.workspace_root = workspace_root;
+        }
+    }
+
+    pub(super) fn resolve_requested_path(&self, file_path: &str) -> PathBuf {
+        let candidate = PathBuf::from(file_path);
+        let joined = if candidate.is_absolute() {
+            candidate
+        } else {
+            self.workspace_root.join(file_path)
+        };
+
+        joined.canonicalize().unwrap_or(joined)
+    }
+
     pub(super) async fn open_document_if_needed(&mut self, file_path: &str) -> Result<String> {
-        let absolute_path = self.workspace_root.join(file_path);
-        // Ensure we have an absolute path for the URI.
-        let absolute_path = absolute_path
-            .canonicalize()
-            .unwrap_or_else(|_| absolute_path.clone());
-        let uri = format!("file://{}", absolute_path.display());
+        let absolute_path = self.resolve_requested_path(file_path);
+        let uri = Self::to_file_uri(&absolute_path)?;
         let content = tokio::fs::read_to_string(&absolute_path)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to read file {}: {}", file_path, e))?;
@@ -85,6 +163,7 @@ impl RustAnalyzerMCPServer {
         let stdout = tokio::io::stdout();
         let mut reader = BufReader::new(stdin);
         let mut writer = BufWriter::new(stdout);
+        let mut transport_mode: Option<TransportMode> = None;
 
         // Handle shutdown signals.
         let running = Arc::new(Mutex::new(true));
@@ -102,27 +181,13 @@ impl RustAnalyzerMCPServer {
                 break;
             }
 
-            let mut line = String::new();
-            let bytes_read = match reader.read_line(&mut line).await {
-                Ok(n) => n,
+            let request = match Self::read_request(&mut reader, &mut transport_mode).await {
+                Ok(Some(req)) => req,
+                Ok(None) => break, // EOF
                 Err(e) => {
-                    error!("Error reading from stdin: {}", e);
+                    error!("Error reading MCP request: {}", e);
                     break;
                 }
-            };
-
-            if bytes_read == 0 {
-                break; // EOF
-            }
-
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-
-            let Ok(request) = serde_json::from_str::<MCPRequest>(line) else {
-                debug!("Failed to parse request: {}", line);
-                continue;
             };
 
             debug!("Received request: {}", request.method);
@@ -135,9 +200,7 @@ impl RustAnalyzerMCPServer {
 
             let response = self.handle_request(request).await;
             let response_json = serde_json::to_string(&response)?;
-            writer.write_all(response_json.as_bytes()).await?;
-            writer.write_all(b"\n").await?;
-            writer.flush().await?;
+            Self::write_response(&mut writer, transport_mode, &response_json).await?;
         }
 
         // Cleanup.
@@ -146,6 +209,97 @@ impl RustAnalyzerMCPServer {
             let _ = client.shutdown().await;
         }
 
+        Ok(())
+    }
+
+    async fn read_request(
+        reader: &mut BufReader<tokio::io::Stdin>,
+        transport_mode: &mut Option<TransportMode>,
+    ) -> Result<Option<MCPRequest>> {
+        loop {
+            let mut line = String::new();
+            let bytes_read = reader.read_line(&mut line).await?;
+            if bytes_read == 0 {
+                return Ok(None);
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            if trimmed.to_ascii_lowercase().starts_with("content-length:") {
+                let len_text = trimmed
+                    .split_once(':')
+                    .map(|(_, v)| v.trim())
+                    .ok_or_else(|| anyhow!("Invalid Content-Length header: {}", trimmed))?;
+                let content_length = len_text
+                    .parse::<usize>()
+                    .map_err(|e| anyhow!("Invalid Content-Length value '{}': {}", len_text, e))?;
+
+                // Read remaining headers until blank line.
+                loop {
+                    let mut header = String::new();
+                    let n = reader.read_line(&mut header).await?;
+                    if n == 0 {
+                        return Ok(None);
+                    }
+                    if header.trim().is_empty() {
+                        break;
+                    }
+                }
+
+                let mut body = vec![0_u8; content_length];
+                reader.read_exact(&mut body).await?;
+                let body_text = String::from_utf8(body)
+                    .map_err(|e| anyhow!("Invalid UTF-8 in MCP frame body: {}", e))?;
+
+                match serde_json::from_str::<MCPRequest>(&body_text) {
+                    Ok(request) => {
+                        *transport_mode = Some(TransportMode::ContentLength);
+                        return Ok(Some(request));
+                    }
+                    Err(e) => {
+                        debug!(
+                            "Failed to parse framed MCP request: {} | body={}",
+                            e, body_text
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            match serde_json::from_str::<MCPRequest>(trimmed) {
+                Ok(request) => {
+                    *transport_mode = Some(TransportMode::JsonLine);
+                    return Ok(Some(request));
+                }
+                Err(e) => {
+                    debug!("Failed to parse line MCP request: {} | line={}", e, trimmed);
+                    continue;
+                }
+            }
+        }
+    }
+
+    async fn write_response(
+        writer: &mut BufWriter<tokio::io::Stdout>,
+        transport_mode: Option<TransportMode>,
+        response_json: &str,
+    ) -> Result<()> {
+        match transport_mode.unwrap_or(TransportMode::JsonLine) {
+            TransportMode::JsonLine => {
+                writer.write_all(response_json.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+            }
+            TransportMode::ContentLength => {
+                let bytes = response_json.as_bytes();
+                let header = format!("Content-Length: {}\r\n\r\n", bytes.len());
+                writer.write_all(header.as_bytes()).await?;
+                writer.write_all(bytes).await?;
+            }
+        }
+        writer.flush().await?;
         Ok(())
     }
 
@@ -232,5 +386,23 @@ impl RustAnalyzerMCPServer {
                 },
             },
         }
+    }
+}
+
+fn find_workspace_root_for_file(file_path: &Path) -> Option<PathBuf> {
+    let mut cursor = if file_path.is_file() {
+        file_path.parent().map(Path::to_path_buf)?
+    } else {
+        file_path.to_path_buf()
+    };
+
+    loop {
+        if cursor.join("Cargo.toml").is_file() {
+            return Some(cursor);
+        }
+        let Some(parent) = cursor.parent() else {
+            return None;
+        };
+        cursor = parent.to_path_buf();
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -126,6 +126,13 @@ impl RustAnalyzerMCPServer {
             };
 
             debug!("Received request: {}", request.method);
+
+            // Notifications do not have `id` and must not receive a JSON-RPC response.
+            if request.id.is_none() {
+                debug!("Ignoring notification without id: {}", request.method);
+                continue;
+            }
+
             let response = self.handle_request(request).await;
             let response_json = serde_json::to_string(&response)?;
             writer.write_all(response_json.as_bytes()).await?;


### PR DESCRIPTION
## Background

  On Windows + Codex CLI, `rust-analyzer-mcp` could list tools, but `tools/call` frequently timed out.

  From investigation, the failures were mainly caused by environment-constrained process startup:

  1. `rust-analyzer` discovery relied too heavily on runtime env vars (`PATH`, `HOME`, `CARGO_HOME`, `RUSTUP_HOME`),
  which may be sanitized in Codex environments.
  2. Even when `rust-analyzer.exe` was found, missing `USERPROFILE`/`HOME` in the child process could cause
  initialization to hang and eventually timeout.

  ## What this PR changes

  ### 1) Stronger rust-analyzer discovery on Windows

  After explicit override (`RUST_ANALYZER_MCP_RUST_ANALYZER_PATH`) and PATH checks, add layered fallbacks:

  - `CARGO_HOME`, `USERPROFILE\\.cargo\\bin`, `HOMEDRIVE+HOMEPATH`
  - `RUSTUP_HOME\\toolchains\\*\\bin`
  - Registry-backed homes from:
    - `HKCU\\Environment`
    - `HKCU\\Volatile Environment`
  - `rustup which rust-analyzer` fallback resolution

  ### 2) Child-process env recovery for rust-analyzer startup

  Before spawning `rust-analyzer` on Windows, if missing in current env, recover and inject:

  - `USERPROFILE`
  - `HOME`
  - `CARGO_HOME`
  - `RUSTUP_HOME`

  This prevents the “binary found, but initialize hangs” failure mode.

  ### 3) Better timeout diagnostics

  LSP timeout errors now include rust-analyzer process status (exited/running), making it easier to distinguish startup
  failures from protocol issues.

  ### 4) Stability improvements in the same execution path

  - LSP request flow now registers `pending` before sending bytes, reducing fast-response race risk.
  - Before first tools call, workspace root can be adjusted from `file_path` (walk up to nearest `Cargo.toml`), avoiding
  startup in a wrong cwd.

  ## Files changed

  - `Cargo.toml` (adds windows-only dependency: `winreg`)
  - `Cargo.lock`
  - `src/lsp/client.rs`
  - `src/mcp/server.rs`
  - `src/mcp/handlers.rs`

  ## Validation

  Validated locally on Windows with MCP `Content-Length` transport:

  - Normal environment: `initialize -> tools/call` succeeds.
  - Constrained environment (HOME/USERPROFILE/CARGO_HOME/RUSTUP_HOME removed, Rust paths removed): `tools/call` still
  succeeds.
  - Release build passes.
----------------
all this is done by codex cli itself, now working on my windows 10 codex cli， maybe it is not the best solution ,just a suggestion.