### PR TITLE
🐛 mcp: Generate valid file URIs on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
  "test-support",
  "tokio",
  "tokio-test",
+ "url",
  "which",
  "wiremock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.10"
 log = "0.4"
 futures = "0.3"
 which = "6.0"
+url = "2.5"
 
 [dev-dependencies]
 # Test support library
@@ -65,4 +66,3 @@ panic = "abort"
 [[bench]]
 name = "concurrent_requests"
 harness = false
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod diagnostics;
 pub mod lsp;
 pub mod mcp;
+pub mod paths;
 pub mod protocol;
 
 pub use mcp::RustAnalyzerMCPServer;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -16,6 +16,7 @@ use tokio::{
 
 use crate::{
     config::{DOCUMENT_OPEN_DELAY_MILLIS, LSP_REQUEST_TIMEOUT_SECS},
+    paths::{absolute_path, directory_uri},
     protocol::lsp::LSPRequest,
 };
 
@@ -32,16 +33,7 @@ pub struct RustAnalyzerClient {
 
 impl RustAnalyzerClient {
     pub fn new(workspace_root: PathBuf) -> Self {
-        // Ensure the workspace root is absolute.
-        let workspace_root = workspace_root.canonicalize().unwrap_or_else(|_| {
-            if workspace_root.is_absolute() {
-                workspace_root.clone()
-            } else {
-                std::env::current_dir()
-                    .unwrap_or_else(|_| PathBuf::from("."))
-                    .join(&workspace_root)
-            }
-        });
+        let workspace_root = absolute_path(workspace_root);
 
         Self {
             process: None,
@@ -204,9 +196,10 @@ impl RustAnalyzerClient {
     }
 
     async fn initialize(&mut self) -> Result<()> {
+        let root_uri = directory_uri(&self.workspace_root)?;
         let init_params = json!({
             "processId": std::process::id(),
-            "rootUri": format!("file://{}", self.workspace_root.display()),
+            "rootUri": root_uri,
             "initializationOptions": {
                 "cargo": {
                     "buildScripts": {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::{
     diagnostics::format_diagnostics,
+    paths::absolute_path,
     protocol::mcp::{ContentItem, ToolResult},
 };
 
@@ -227,15 +228,7 @@ async fn handle_set_workspace(
 
     // Set new workspace with proper absolute path handling.
     let workspace_root = PathBuf::from(workspace_path);
-    server.workspace_root = workspace_root.canonicalize().unwrap_or_else(|_| {
-        if workspace_root.is_absolute() {
-            workspace_root.clone()
-        } else {
-            std::env::current_dir()
-                .unwrap_or_else(|_| PathBuf::from("."))
-                .join(&workspace_root)
-        }
-    });
+    server.workspace_root = absolute_path(workspace_root);
 
     // Start the new client automatically.
     server.ensure_client_started().await?;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,6 +9,7 @@ use tokio::{
 
 use crate::{
     lsp::RustAnalyzerClient,
+    paths::{absolute_path, file_uri},
     protocol::mcp::{MCPError, MCPRequest, MCPResponse},
 };
 
@@ -32,17 +33,7 @@ impl RustAnalyzerMCPServer {
     }
 
     pub fn with_workspace(workspace_root: PathBuf) -> Self {
-        // Ensure the workspace root is absolute.
-        let workspace_root = workspace_root.canonicalize().unwrap_or_else(|_| {
-            // If canonicalize fails, try to make it absolute.
-            if workspace_root.is_absolute() {
-                workspace_root.clone()
-            } else {
-                std::env::current_dir()
-                    .unwrap_or_else(|_| PathBuf::from("."))
-                    .join(&workspace_root)
-            }
-        });
+        let workspace_root = absolute_path(workspace_root);
 
         Self {
             client: None,
@@ -60,15 +51,18 @@ impl RustAnalyzerMCPServer {
     }
 
     pub(super) async fn open_document_if_needed(&mut self, file_path: &str) -> Result<String> {
-        let absolute_path = self.workspace_root.join(file_path);
-        // Ensure we have an absolute path for the URI.
-        let absolute_path = absolute_path
-            .canonicalize()
-            .unwrap_or_else(|_| absolute_path.clone());
-        let uri = format!("file://{}", absolute_path.display());
+        let file_path = PathBuf::from(file_path);
+        let absolute_path = if file_path.is_absolute() {
+            absolute_path(file_path)
+        } else {
+            absolute_path(self.workspace_root.join(file_path))
+        };
+        let uri = file_uri(&absolute_path)?;
         let content = tokio::fs::read_to_string(&absolute_path)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to read file {}: {}", file_path, e))?;
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to read file {}: {}", absolute_path.display(), e)
+            })?;
 
         let Some(client) = &mut self.client else {
             return Err(anyhow::anyhow!("Client not initialized"));

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,50 @@
+use anyhow::{anyhow, Result};
+use std::path::{Path, PathBuf};
+use url::Url;
+
+pub fn absolute_path(path: PathBuf) -> PathBuf {
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(path)
+    };
+
+    normalize_path(path)
+}
+
+pub fn file_uri(path: &Path) -> Result<String> {
+    Url::from_file_path(path)
+        .map(|url| url.to_string())
+        .map_err(|_| anyhow!("failed to convert path to file URI: {}", path.display()))
+}
+
+pub fn directory_uri(path: &Path) -> Result<String> {
+    Url::from_directory_path(path)
+        .map(|url| url.to_string())
+        .map_err(|_| {
+            anyhow!(
+                "failed to convert path to directory URI: {}",
+                path.display()
+            )
+        })
+}
+
+#[cfg(windows)]
+fn normalize_path(path: PathBuf) -> PathBuf {
+    let path_str = path.to_string_lossy();
+
+    if let Some(rest) = path_str.strip_prefix(r"\\?\UNC\") {
+        PathBuf::from(format!(r"\\{rest}"))
+    } else if let Some(rest) = path_str.strip_prefix(r"\\?\") {
+        PathBuf::from(rest)
+    } else {
+        path
+    }
+}
+
+#[cfg(not(windows))]
+fn normalize_path(path: PathBuf) -> PathBuf {
+    path
+}


### PR DESCRIPTION
## Summary

- add shared path helpers for absolute path normalization and file/directory URI conversion
- build LSP `rootUri` and opened document URIs with `url::Url`
- normalize Windows verbatim paths before turning them into LSP file URIs

## Why

Formatting `PathBuf::display()` into `file://...` produces invalid file URIs on Windows, for example drive-letter paths are emitted as `file://C:\...`. rust-analyzer rejects those URIs, so MCP file-level requests can fail before analysis starts.

## Validation

- `cargo +nightly fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build --release`

`cargo test --all-features` and `cargo test -p rust-analyzer-mcp --lib` currently do not compile on Windows before reaching this change because `test-support` imports `std::os::unix::net::{UnixStream, UnixListener}`.
