### PR TITLE
🐛 lsp: Avoid request response races

### DIFF
--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -23,7 +23,7 @@ pub struct RustAnalyzerClient {
     pub(super) process: Option<Child>,
     pub(super) request_id: Arc<Mutex<u64>>,
     pub(super) workspace_root: PathBuf,
-    pub(super) stdin: Option<BufWriter<tokio::process::ChildStdin>>,
+    pub(super) stdin: Option<Arc<Mutex<BufWriter<tokio::process::ChildStdin>>>>,
     pub(super) pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     pub(super) initialized: bool,
     pub(super) open_documents: Arc<Mutex<HashSet<String>>>,
@@ -102,12 +102,14 @@ impl RustAnalyzerClient {
             .take()
             .ok_or_else(|| anyhow!("Failed to get stderr"))?;
 
-        self.stdin = Some(BufWriter::new(stdin));
+        let stdin = Arc::new(Mutex::new(BufWriter::new(stdin)));
+        self.stdin = Some(Arc::clone(&stdin));
 
         // Start connection handlers.
         super::connection::start_handlers(
             stdout,
             stderr,
+            stdin,
             Arc::clone(&self.pending_requests),
             Arc::clone(&self.diagnostics),
         );
@@ -138,6 +140,14 @@ impl RustAnalyzerClient {
         Ok(())
     }
 
+    pub fn is_running(&mut self) -> bool {
+        let Some(process) = &mut self.process else {
+            return false;
+        };
+
+        matches!(process.try_wait(), Ok(None))
+    }
+
     pub(super) async fn send_notification(
         &mut self,
         method: &str,
@@ -154,10 +164,11 @@ impl RustAnalyzerClient {
 
         info!("Sending LSP notification: {}", method);
 
-        let Some(stdin) = &mut self.stdin else {
+        let Some(stdin) = &self.stdin else {
             return Err(anyhow!("No stdin available"));
         };
 
+        let mut stdin = stdin.lock().await;
         stdin.write_all(message.as_bytes()).await?;
         stdin.flush().await?;
         Ok(())
@@ -185,22 +196,50 @@ impl RustAnalyzerClient {
 
         info!("Sending LSP request: {} with params: {:?}", method, params);
 
-        let Some(stdin) = &mut self.stdin else {
-            return Err(anyhow!("No stdin available"));
-        };
-
-        stdin.write_all(message.as_bytes()).await?;
-        stdin.flush().await?;
-
-        // Set up response channel.
+        // Register the pending response before writing the request. Some LSP
+        // requests (especially shutdown and small file-level queries) can be
+        // answered immediately; registering afterwards races the reader task.
         let (tx, rx) = oneshot::channel();
         self.pending_requests.lock().await.insert(id, tx);
 
-        // Wait for response with timeout.
-        tokio::time::timeout(Duration::from_secs(LSP_REQUEST_TIMEOUT_SECS), rx)
+        let Some(stdin) = &self.stdin else {
+            self.pending_requests.lock().await.remove(&id);
+            return Err(anyhow!("No stdin available"));
+        };
+
+        {
+            let mut stdin = stdin.lock().await;
+            if let Err(err) = stdin.write_all(message.as_bytes()).await {
+                self.pending_requests.lock().await.remove(&id);
+                return Err(err.into());
+            }
+            if let Err(err) = stdin.flush().await {
+                self.pending_requests.lock().await.remove(&id);
+                return Err(err.into());
+            }
+        }
+
+        self.receive_response(id, rx, Duration::from_secs(LSP_REQUEST_TIMEOUT_SECS))
             .await
-            .map_err(|_| anyhow!("Request timeout"))?
-            .map_err(|_| anyhow!("Request cancelled"))
+    }
+
+    async fn receive_response(
+        &mut self,
+        id: u64,
+        rx: oneshot::Receiver<Value>,
+        timeout: Duration,
+    ) -> Result<Value> {
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(_)) => {
+                self.pending_requests.lock().await.remove(&id);
+                Err(anyhow!("Request cancelled"))
+            }
+            Err(_) => {
+                self.pending_requests.lock().await.remove(&id);
+                Err(anyhow!("Request timeout"))
+            }
+        }
     }
 
     async fn initialize(&mut self) -> Result<()> {
@@ -281,11 +320,6 @@ impl RustAnalyzerClient {
         self.send_notification("initialized", Some(json!({})))
             .await?;
 
-        // Request workspace reload to trigger cargo check.
-        self.send_request("rust-analyzer/reloadWorkspace", None)
-            .await
-            .ok();
-
         Ok(())
     }
 
@@ -341,7 +375,9 @@ impl RustAnalyzerClient {
 
     pub async fn shutdown(&mut self) -> Result<()> {
         if self.initialized {
-            let _ = self.send_request("shutdown", None).await;
+            let _ = self
+                .send_request_with_timeout("shutdown", None, Duration::from_secs(1))
+                .await;
             let _ = self.send_notification("exit", None).await;
         }
 
@@ -356,6 +392,52 @@ impl RustAnalyzerClient {
         self.diagnostics.lock().await.clear();
         self.initialized = false;
         Ok(())
+    }
+
+    async fn send_request_with_timeout(
+        &mut self,
+        method: &str,
+        params: Option<Value>,
+        timeout: Duration,
+    ) -> Result<Value> {
+        let mut request_id_lock = self.request_id.lock().await;
+        let id = *request_id_lock;
+        *request_id_lock += 1;
+        drop(request_id_lock);
+
+        let request = LSPRequest {
+            jsonrpc: "2.0".to_string(),
+            id,
+            method: method.to_string(),
+            params: params.clone(),
+        };
+
+        let content = serde_json::to_string(&request)?;
+        let message = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
+
+        info!("Sending LSP request: {} with params: {:?}", method, params);
+
+        let (tx, rx) = oneshot::channel();
+        self.pending_requests.lock().await.insert(id, tx);
+
+        let Some(stdin) = &self.stdin else {
+            self.pending_requests.lock().await.remove(&id);
+            return Err(anyhow!("No stdin available"));
+        };
+
+        {
+            let mut stdin = stdin.lock().await;
+            if let Err(err) = stdin.write_all(message.as_bytes()).await {
+                self.pending_requests.lock().await.remove(&id);
+                return Err(err.into());
+            }
+            if let Err(err) = stdin.flush().await {
+                self.pending_requests.lock().await.remove(&id);
+                return Err(err.into());
+            }
+        }
+
+        self.receive_response(id, rx, timeout).await
     }
 }
 

--- a/src/lsp/connection.rs
+++ b/src/lsp/connection.rs
@@ -1,16 +1,18 @@
 use log::{debug, error, info};
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::{collections::HashMap, sync::Arc};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncReadExt, BufReader},
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter},
+    process::{ChildStderr, ChildStdin, ChildStdout},
     sync::{oneshot, Mutex},
 };
 
 use crate::protocol::lsp::LSPResponse;
 
 pub fn start_handlers(
-    stdout: tokio::process::ChildStdout,
-    stderr: tokio::process::ChildStderr,
+    stdout: ChildStdout,
+    stderr: ChildStderr,
+    stdin: Arc<Mutex<BufWriter<ChildStdin>>>,
     pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
 ) {
@@ -18,10 +20,10 @@ pub fn start_handlers(
     tokio::spawn(handle_stderr(stderr));
 
     // Start response handler task.
-    tokio::spawn(handle_stdout(stdout, pending_requests, diagnostics));
+    tokio::spawn(handle_stdout(stdout, stdin, pending_requests, diagnostics));
 }
 
-async fn handle_stderr(stderr: tokio::process::ChildStderr) {
+async fn handle_stderr(stderr: ChildStderr) {
     let mut reader = BufReader::new(stderr);
     let mut buffer = String::new();
 
@@ -47,7 +49,8 @@ async fn handle_stderr(stderr: tokio::process::ChildStderr) {
 }
 
 async fn handle_stdout(
-    stdout: tokio::process::ChildStdout,
+    stdout: ChildStdout,
+    stdin: Arc<Mutex<BufWriter<ChildStdin>>>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
 ) {
@@ -56,13 +59,18 @@ async fn handle_stdout(
 
     loop {
         buffer.clear();
-        let Ok(bytes_read) = reader.read_line(&mut buffer).await else {
-            error!("Error reading from rust-analyzer stdout");
-            break;
+        let bytes_read = match reader.read_line(&mut buffer).await {
+            Ok(bytes_read) => bytes_read,
+            Err(err) => {
+                error!("Error reading from rust-analyzer stdout: {}", err);
+                cancel_pending_requests(&pending).await;
+                break;
+            }
         };
 
         if bytes_read == 0 {
-            break; // EOF
+            cancel_pending_requests(&pending).await;
+            break;
         }
 
         if buffer.trim().is_empty() {
@@ -90,8 +98,13 @@ async fn handle_stdout(
         let response_str = String::from_utf8_lossy(&json_buffer);
         debug!("Received LSP message: {}", response_str);
 
-        handle_lsp_message(&json_buffer, &pending, &diagnostics).await;
+        handle_lsp_message(&json_buffer, &stdin, &pending, &diagnostics).await;
     }
+}
+
+async fn cancel_pending_requests(pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>) {
+    let mut pending_lock = pending.lock().await;
+    pending_lock.clear();
 }
 
 fn parse_content_length(header: &str) -> Option<usize> {
@@ -102,6 +115,7 @@ fn parse_content_length(header: &str) -> Option<usize> {
 
 async fn handle_lsp_message(
     json_buffer: &[u8],
+    stdin: &Arc<Mutex<BufWriter<ChildStdin>>>,
     pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: &Arc<Mutex<HashMap<String, Vec<Value>>>>,
 ) {
@@ -116,6 +130,14 @@ async fn handle_lsp_message(
     // Check if it's a notification (has method but no id).
     if json_value.get("method").is_some() && json_value.get("id").is_none() {
         handle_notification(json_value, diagnostics).await;
+        return;
+    }
+
+    // rust-analyzer can send client-side LSP requests such as
+    // workspace/configuration. The MCP bridge must answer them, otherwise some
+    // rust-analyzer operations can stall while waiting for a client response.
+    if json_value.get("method").is_some() && json_value.get("id").is_some() {
+        handle_server_request(json_value, stdin).await;
         return;
     }
 
@@ -141,6 +163,49 @@ async fn handle_lsp_message(
         info!("Sending result for request {}: {:?}", id, result);
         let _ = sender.send(result);
     }
+}
+
+async fn handle_server_request(json_value: Value, stdin: &Arc<Mutex<BufWriter<ChildStdin>>>) {
+    let id = json_value.get("id").cloned().unwrap_or(Value::Null);
+    let method = json_value
+        .get("method")
+        .and_then(|method| method.as_str())
+        .unwrap_or("<unknown>");
+
+    debug!("Received rust-analyzer request: {}", method);
+
+    let result = match method {
+        "workspace/configuration" => {
+            let item_count = json_value
+                .get("params")
+                .and_then(|params| params.get("items"))
+                .and_then(|items| items.as_array())
+                .map_or(0, Vec::len);
+            json!(vec![json!({}); item_count])
+        }
+        _ => Value::Null,
+    };
+
+    let response = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    });
+
+    if let Err(err) = send_lsp_message(stdin, response).await {
+        error!("failed to answer rust-analyzer request {method}: {err}");
+    }
+}
+
+async fn send_lsp_message(
+    stdin: &Arc<Mutex<BufWriter<ChildStdin>>>,
+    message: Value,
+) -> Result<(), std::io::Error> {
+    let content = serde_json::to_string(&message)?;
+    let envelope = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
+    let mut stdin = stdin.lock().await;
+    stdin.write_all(envelope.as_bytes()).await?;
+    stdin.flush().await
 }
 
 async fn handle_notification(

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -48,6 +48,10 @@ pub async fn handle_tool_call(
     tool_name: &str,
     args: Value,
 ) -> Result<ToolResult> {
+    if tool_name == "rust_analyzer_set_workspace" {
+        return handle_set_workspace(server, args).await;
+    }
+
     server.ensure_client_started().await?;
 
     match tool_name {
@@ -58,7 +62,6 @@ pub async fn handle_tool_call(
         "rust_analyzer_symbols" => handle_symbols(server, args).await,
         "rust_analyzer_format" => handle_format(server, args).await,
         "rust_analyzer_code_actions" => handle_code_actions(server, args).await,
-        "rust_analyzer_set_workspace" => handle_set_workspace(server, args).await,
         "rust_analyzer_diagnostics" => handle_diagnostics(server, args).await,
         "rust_analyzer_workspace_diagnostics" => handle_workspace_diagnostics(server, args).await,
         _ => Err(anyhow!("Unknown tool: {}", tool_name)),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -51,6 +51,13 @@ impl RustAnalyzerMCPServer {
     }
 
     pub(super) async fn ensure_client_started(&mut self) -> Result<()> {
+        if let Some(client) = &mut self.client {
+            if !client.is_running() {
+                let _ = client.shutdown().await;
+                self.client = None;
+            }
+        }
+
         if self.client.is_none() {
             let mut client = RustAnalyzerClient::new(self.workspace_root.clone());
             client.start().await?;


### PR DESCRIPTION
## Summary

- register pending LSP response channels before writing requests to rust-analyzer
- share the rust-analyzer stdin writer with the stdout reader so server-side LSP requests can be answered
- respond to `workspace/configuration` requests from rust-analyzer
- cancel pending LSP requests when rust-analyzer stdout closes or errors
- restart the client when the rust-analyzer subprocess has exited
- avoid starting a default client before handling `rust_analyzer_set_workspace`
- keep shutdown best-effort with a short timeout before killing the subprocess
- remove the synchronous `rust-analyzer/reloadWorkspace` request during initialization

## Why

Some rust-analyzer responses can arrive immediately. The previous ordering wrote the LSP request first and only registered the pending response channel afterwards, so a fast response could be dropped and the caller would wait until the request timeout.

The bridge also did not answer rust-analyzer client-side requests such as `workspace/configuration`, which can leave rust-analyzer waiting for a client response. In addition, `rust_analyzer_set_workspace` first started a client for the current/default directory and then immediately shut it down, so workspace switching could spend a full timeout on work that was about to be discarded.

If rust-analyzer exits while requests are pending, the bridge should cancel those requests and allow a later tool call to restart the client instead of keeping a dead client around and timing out repeatedly.

## Validation

- `cargo +nightly fmt --all`
- `git diff --check`
- `cargo clippy -- -D warnings`
- `cargo build --release`

`cargo test --all-features` currently does not compile on Windows before reaching this change because `test-support` imports `std::os::unix::net::{UnixStream, UnixListener}`.