### PR TITLE
🐛 fix(protocol): silently handle MCP notifications without emitting error responses

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -126,11 +126,14 @@ impl RustAnalyzerMCPServer {
             };
 
             debug!("Received request: {}", request.method);
-            let response = self.handle_request(request).await;
-            let response_json = serde_json::to_string(&response)?;
-            writer.write_all(response_json.as_bytes()).await?;
-            writer.write_all(b"\n").await?;
-            writer.flush().await?;
+            // Only send a response if handle_request returned Some(response) (notifications return None).
+            // See handle_request() for details on how notifications are handled.
+            if let Some(response) = self.handle_request(request).await {
+                let response_json = serde_json::to_string(&response)?;
+                writer.write_all(response_json.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await?;
+            }
         }
 
         // Cleanup.
@@ -142,8 +145,15 @@ impl RustAnalyzerMCPServer {
         Ok(())
     }
 
-    async fn handle_request(&mut self, request: MCPRequest) -> MCPResponse {
-        match request.method.as_str() {
+    async fn handle_request(&mut self, request: MCPRequest) -> Option<MCPResponse> {
+        // Handle MCP notifications (e.g. notifications/initialized, notifications/cancelled).
+        // Per JSON-RPC 2.0 and MCP spec, notifications do not contain an id and MUST NOT produce a response.
+        if request.id.is_none() || request.method.starts_with("notifications/") {
+            debug!("Silently handled notification: {}", request.method);
+            return None;
+        }
+
+        let response = match request.method.as_str() {
             "initialize" => MCPResponse::Success {
                 jsonrpc: "2.0".to_string(),
                 id: request.id,
@@ -167,7 +177,7 @@ impl RustAnalyzerMCPServer {
             },
             "tools/call" => {
                 let Some(params) = request.params else {
-                    return MCPResponse::Error {
+                    return Some(MCPResponse::Error {
                         jsonrpc: "2.0".to_string(),
                         id: request.id,
                         error: MCPError {
@@ -175,11 +185,11 @@ impl RustAnalyzerMCPServer {
                             message: "Invalid params".to_string(),
                             data: None,
                         },
-                    };
+                    });
                 };
 
                 let Some(tool_name) = params["name"].as_str() else {
-                    return MCPResponse::Error {
+                    return Some(MCPResponse::Error {
                         jsonrpc: "2.0".to_string(),
                         id: request.id,
                         error: MCPError {
@@ -187,7 +197,7 @@ impl RustAnalyzerMCPServer {
                             message: "Missing tool name".to_string(),
                             data: None,
                         },
-                    };
+                    });
                 };
 
                 let args = params
@@ -224,6 +234,8 @@ impl RustAnalyzerMCPServer {
                     data: None,
                 },
             },
-        }
+        };
+
+        Some(response)
     }
 }

--- a/tests/unit/protocol/request_tests.rs
+++ b/tests/unit/protocol/request_tests.rs
@@ -104,6 +104,14 @@ fn test_notification_without_id() {
 }
 
 #[test]
+fn test_mcp_notifications_initialized() {
+    let raw = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+    let request: MCPRequest = from_str(raw).unwrap();
+    assert_eq!(request.method, "notifications/initialized");
+    assert!(request.id.is_none());
+}
+
+#[test]
 fn test_tool_call_request() {
     let tool_call = MCPRequest {
         jsonrpc: "2.0".to_string(),


### PR DESCRIPTION
# Repro Steps

1. Install `rust-analyzer-mcp` using `cargo install --force rust-analyzer-mcp`.

2. [Install](https://antigravity.google/docs/cli/reference) Antigravity CLI (`agy`) and
   configure it to use `rust-analyzer-mcp` as an MCP server named `rust-analyzer` by
   adding the following configuration to your Rust project's `.gemini/settings.json` (or
   global `~/.gemini/config/mcp_config.json`):

   ```json
   {
     "mcpServers": {
       "rust-analyzer": {
         "command": "rust-analyzer-mcp",
         "args": []
       }
     }
   }
   ```

3. Open Antigravity CLI (`agy`) in a folder containing a Rust project and run the `/mcp`
   slash command. You will see the following error:

   ```text
   >  ✗ rust-analyzer  error: failed to get tools: calling "tools/list": invalid request
   ```

> Note: These repro steps also apply to Antigravity IDE.

# Expected Behavior

The [JSON-RPC 2.0][1] and [Model Context Protocol (MCP)][2] specifications state that
notifications (such as `notifications/initialized` and `notifications/cancelled`) do not
contain an `id` and should not write a response or error to `stdout`.

[1]: https://www.jsonrpc.org/specification#notification
[2]: https://modelcontextprotocol.io/docs/concepts/architecture#notifications

Currently, receiving `notifications/initialized` causes `rust-analyzer-mcp` to execute the
wildcard error branch in `handle_request`, returning:

```json
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32601,
    "message": "Method not found: notifications/initialized",
    "data": null
  }
}
```

Because this unexpected error response is written to `stdout`, MCP clients (such as
Google Antigravity CLI / `agy`) that are waiting for the response to their next request
(e.g. `tools/list` with `id: 2`) get out of sync and fail with:

```text
>  ✗ rust-analyzer  error: failed to get tools: calling "tools/list": invalid request
```

# Fix

1. **Silent Notification Handling:** Updated `handle_request()` to return
   `Option<MCPResponse>`. Notifications (where `request.id.is_none()` or
   `request.method.starts_with("notifications/")`) now return `None`.
2. **Output Stream Control:** Updated the `run()` loop to only serialize and write a
   response to `stdout` when `handle_request()` returns `Some(response)`.
3. **Unit Tests:** Added a unit test in `tests/unit/protocol/request_tests.rs` verifying
   notification deserialization without `id`.
