### PR TITLE
🐛 Fix server never exiting on SIGINT/SIGTERM

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,8 @@
 /// Timeout for LSP requests in seconds.
 pub const LSP_REQUEST_TIMEOUT_SECS: u64 = 30;
 
+/// Timeout for the graceful part of the rust-analyzer shutdown, in seconds.
+pub const GRACEFUL_SHUTDOWN_TIMEOUT_SECS: u64 = 5;
+
 /// Delay after opening a document to allow rust-analyzer to process it.
 pub const DOCUMENT_OPEN_DELAY_MILLIS: u64 = 200;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -15,7 +15,9 @@ use tokio::{
 };
 
 use crate::{
-    config::{DOCUMENT_OPEN_DELAY_MILLIS, LSP_REQUEST_TIMEOUT_SECS},
+    config::{
+        DOCUMENT_OPEN_DELAY_MILLIS, GRACEFUL_SHUTDOWN_TIMEOUT_SECS, LSP_REQUEST_TIMEOUT_SECS,
+    },
     protocol::lsp::LSPRequest,
 };
 
@@ -339,12 +341,29 @@ impl RustAnalyzerClient {
         Ok(())
     }
 
+    /// Shuts rust-analyzer down, attempting the graceful LSP handshake first.
     pub async fn shutdown(&mut self) -> Result<()> {
         if self.initialized {
-            let _ = self.send_request("shutdown", None).await;
-            let _ = self.send_notification("exit", None).await;
+            // Bound the handshake so a wedged rust-analyzer cannot stall the shutdown.
+            let handshake = async {
+                let _ = self.send_request("shutdown", None).await;
+                let _ = self.send_notification("exit", None).await;
+            };
+            let timeout = Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECS);
+            if tokio::time::timeout(timeout, handshake).await.is_err() {
+                info!("Graceful shutdown timed out");
+            }
         }
 
+        self.force_kill().await;
+        Ok(())
+    }
+
+    /// Kills rust-analyzer immediately, without the LSP shutdown handshake.
+    ///
+    /// Meant for when a graceful [`Self::shutdown`] was aborted, so the process must not be left
+    /// behind.
+    pub async fn force_kill(&mut self) {
         if let Some(mut process) = self.process.take() {
             // Kill the process and wait for it to actually exit.
             let _ = process.kill().await;
@@ -355,7 +374,6 @@ impl RustAnalyzerClient {
         self.open_documents.lock().await.clear();
         self.diagnostics.lock().await.clear();
         self.initialized = false;
-        Ok(())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,57 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use std::path::PathBuf;
 
 use rust_analyzer_mcp::RustAnalyzerMCPServer;
+
+const USAGE: &str = "\
+MCP server for rust-analyzer integration.
+
+Usage: rust-analyzer-mcp [--] [WORKSPACE]
+
+Arguments:
+  [WORKSPACE]  Path to the workspace root [default: current directory]
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
 
 fn main() -> Result<()> {
     // Initialize logging.
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    // Get workspace path from command line or use current directory.
-    let workspace_path = std::env::args()
-        .nth(1)
-        .map(PathBuf::from)
+    // Get workspace path from command line or use current directory. args_os() instead of
+    // args() so a non-UTF-8 workspace path is passed through rather than panicking.
+    let mut args = std::env::args_os().skip(1);
+    let workspace_path = match args.next() {
+        // A lone "--" ends option parsing, allowing a workspace path that starts with '-'.
+        Some(arg) if arg == "--" => args.next().map(PathBuf::from),
+        Some(arg) => match arg.to_str() {
+            Some("--help") | Some("-h") => {
+                print!("{USAGE}");
+                return Ok(());
+            }
+            Some("--version") | Some("-V") => {
+                println!("rust-analyzer-mcp {}", env!("CARGO_PKG_VERSION"));
+                return Ok(());
+            }
+            Some(opt) if opt.starts_with('-') => bail!("unknown option '{opt}'\n\n{USAGE}"),
+            _ => Some(PathBuf::from(arg)),
+        },
+        None => None,
+    };
+    let workspace_path = workspace_path
         .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
+    if let Some(extra) = args.next() {
+        bail!(
+            "unexpected extra argument '{}'\n\n{USAGE}",
+            extra.to_string_lossy()
+        );
+    }
 
     // Create and run the server, catching panics so an unwind cannot bypass the runtime
-    // shutdown below.
+    // shutdown below. This only matters for debug builds and tests: release builds abort on
+    // panic.
     let mut server = RustAnalyzerMCPServer::with_workspace(workspace_path);
     let runtime = tokio::runtime::Runtime::new()?;
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 
 use rust_analyzer_mcp::RustAnalyzerMCPServer;
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     // Initialize logging.
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -14,9 +13,21 @@ async fn main() -> Result<()> {
         .map(PathBuf::from)
         .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
 
-    // Create and run the server.
+    // Create and run the server, catching panics so an unwind cannot bypass the runtime
+    // shutdown below.
     let mut server = RustAnalyzerMCPServer::with_workspace(workspace_path);
-    server.run().await?;
+    let runtime = tokio::runtime::Runtime::new()?;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        runtime.block_on(server.run())
+    }));
 
-    Ok(())
+    // tokio's stdin reader parks an uncancellable blocking read(2) on a pool thread. A normal
+    // runtime drop waits for it to finish, hanging the process when shutdown was triggered by a
+    // signal rather than stdin EOF.
+    runtime.shutdown_background();
+
+    match result {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -75,6 +75,12 @@ impl RustAnalyzerMCPServer {
         Ok(uri)
     }
 
+    /// Runs the server until its stdin reaches EOF or a shutdown signal arrives.
+    ///
+    /// Installs process-wide signal handlers that remain in effect after this returns. Reads
+    /// stdin through [`tokio::io::stdin`], whose parked blocking read cannot be cancelled: after
+    /// a signal-triggered exit the caller must not wait for the runtime to shut down on its own.
+    /// See this crate's `main.rs`, which uses [`tokio::runtime::Runtime::shutdown_background`].
     pub async fn run(&mut self) -> Result<()> {
         info!("Starting rust-analyzer MCP server");
 
@@ -295,12 +301,21 @@ impl RustAnalyzerMCPServer {
 
 /// Merged stream of the signals that request server shutdown.
 ///
-/// SIGINT and SIGTERM on Unix, Ctrl+C events elsewhere.
+/// SIGINT, SIGTERM and SIGHUP on Unix; Ctrl+C and console-close events on Windows. The streams
+/// are persistent, so signals delivered while no `recv()` is pending stay latched instead of
+/// falling through to the default disposition. Note that registering SIGHUP also overrides an
+/// inherited SIG_IGN disposition (e.g. from nohup), so a hangup always shuts the server down.
 struct ShutdownSignal {
     #[cfg(unix)]
     sigint: tokio::signal::unix::Signal,
     #[cfg(unix)]
     sigterm: tokio::signal::unix::Signal,
+    #[cfg(unix)]
+    sighup: tokio::signal::unix::Signal,
+    #[cfg(windows)]
+    ctrl_c: tokio::signal::windows::CtrlC,
+    #[cfg(windows)]
+    ctrl_close: tokio::signal::windows::CtrlClose,
 }
 
 impl ShutdownSignal {
@@ -312,9 +327,19 @@ impl ShutdownSignal {
             Ok(Self {
                 sigint: signal(SignalKind::interrupt())?,
                 sigterm: signal(SignalKind::terminate())?,
+                sighup: signal(SignalKind::hangup())?,
             })
         }
-        #[cfg(not(unix))]
+        #[cfg(windows)]
+        {
+            use tokio::signal::windows;
+
+            Ok(Self {
+                ctrl_c: windows::ctrl_c()?,
+                ctrl_close: windows::ctrl_close()?,
+            })
+        }
+        #[cfg(not(any(unix, windows)))]
         Ok(Self {})
     }
 
@@ -325,11 +350,20 @@ impl ShutdownSignal {
             tokio::select! {
                 _ = self.sigint.recv() => {}
                 _ = self.sigterm.recv() => {}
+                _ = self.sighup.recv() => {}
             }
         }
-        #[cfg(not(unix))]
+        #[cfg(windows)]
         {
-            let _ = tokio::signal::ctrl_c().await;
+            tokio::select! {
+                _ = self.ctrl_c.recv() => {}
+                _ = self.ctrl_close.recv() => {}
+            }
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            // No signal support; only a stdin EOF stops the server.
+            std::future::pending::<()>().await;
         }
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -222,7 +222,7 @@ impl RustAnalyzerMCPServer {
                     "protocolVersion": "2024-11-05",
                     "serverInfo": {
                         "name": "rust-analyzer-mcp",
-                        "version": "0.1.0"
+                        "version": env!("CARGO_PKG_VERSION")
                     },
                     "capabilities": {
                         "tools": {}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
 use log::{debug, error, info};
 use serde_json::json;
-use std::{path::PathBuf, sync::Arc};
-use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
-    sync::Mutex,
-};
+use std::path::PathBuf;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 
 use crate::{
     lsp::RustAnalyzerClient,
@@ -86,29 +83,37 @@ impl RustAnalyzerMCPServer {
         let mut reader = BufReader::new(stdin);
         let mut writer = BufWriter::new(stdout);
 
-        // Handle shutdown signals.
-        let running = Arc::new(Mutex::new(true));
-        let running_clone = Arc::clone(&running);
-
-        tokio::spawn(async move {
-            let _ = tokio::signal::ctrl_c().await;
-            info!("Received shutdown signal");
-            *running_clone.lock().await = false;
-        });
+        // Created once, up front: the streams buffer signals delivered while a request is being
+        // handled, and installing a handler permanently replaces the default disposition, so
+        // every signal must be consumed here to have an effect.
+        let mut shutdown = ShutdownSignal::new()?;
+        // How many shutdown signals were consumed; the second one escalates the cleanup below.
+        let mut signals_seen = 0u32;
+        // The first fatal I/O error, reported only after the cleanup ran.
+        let mut result = Ok(());
 
         loop {
-            // Check if we should stop.
-            if !*running.lock().await {
-                break;
-            }
-
             let mut line = String::new();
-            let bytes_read = match reader.read_line(&mut line).await {
-                Ok(n) => n,
-                Err(e) => {
-                    error!("Error reading from stdin: {}", e);
+            // read_line() is not cancellation-safe, but the partially read line is only lost when
+            // we shut down and discard it anyway.
+            let bytes_read = tokio::select! {
+                // Biased with the signal arm first: a signal that latched while a request was
+                // being handled must win over lines already buffered on stdin, so that no new
+                // request is accepted after shutdown was requested.
+                biased;
+                _ = shutdown.recv() => {
+                    info!("Received shutdown signal");
+                    signals_seen += 1;
                     break;
                 }
+                read = reader.read_line(&mut line) => match read {
+                    Ok(n) => n,
+                    Err(e) => {
+                        error!("Error reading from stdin: {}", e);
+                        result = Err(e.into());
+                        break;
+                    }
+                },
             };
 
             if bytes_read == 0 {
@@ -126,20 +131,80 @@ impl RustAnalyzerMCPServer {
             };
 
             debug!("Received request: {}", request.method);
-            let response = self.handle_request(request).await;
-            let response_json = serde_json::to_string(&response)?;
-            writer.write_all(response_json.as_bytes()).await?;
-            writer.write_all(b"\n").await?;
-            writer.flush().await?;
+            // A shutdown signal must not wait for the request to finish: a tool call that
+            // cold-starts rust-analyzer can run for minutes.
+            let response = tokio::select! {
+                biased;
+                _ = shutdown.recv() => {
+                    info!("Received shutdown signal");
+                    signals_seen += 1;
+                    break;
+                }
+                response = self.handle_request(request) => response,
+            };
+            // Break on errors instead of returning so rust-analyzer still gets cleaned up.
+            let response_json = match serde_json::to_string(&response) {
+                Ok(json) => json,
+                Err(e) => {
+                    error!("Failed to serialize response: {}", e);
+                    result = Err(e.into());
+                    break;
+                }
+            };
+            // Also raced against the signals: if the host stops reading stdout, a response that
+            // fills the pipe would otherwise block here forever with the signals unpolled.
+            let written = async {
+                writer.write_all(response_json.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await
+            };
+            let written = tokio::select! {
+                biased;
+                _ = shutdown.recv() => {
+                    info!("Received shutdown signal");
+                    signals_seen += 1;
+                    break;
+                }
+                written = written => written,
+            };
+            if let Err(e) = written {
+                error!("Error writing to stdout: {}", e);
+                result = Err(e.into());
+                break;
+            }
         }
 
-        // Cleanup.
+        // Cleanup. client.shutdown() bounds its own graceful handshake and always ends up
+        // killing the process, so this cannot stall. A second signal — counting the one that may
+        // have triggered the exit — skips the handshake and kills rust-analyzer immediately.
         info!("Shutting down");
         if let Some(client) = &mut self.client {
-            let _ = client.shutdown().await;
+            let graceful = {
+                let shutting_down = client.shutdown();
+                tokio::pin!(shutting_down);
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = shutdown.recv() => {
+                            signals_seen += 1;
+                            if signals_seen >= 2 {
+                                info!("Received another shutdown signal, killing rust-analyzer");
+                                break false;
+                            }
+                        }
+                        res = &mut shutting_down => {
+                            let _ = res;
+                            break true;
+                        }
+                    }
+                }
+            };
+            if !graceful {
+                client.force_kill().await;
+            }
         }
 
-        Ok(())
+        result
     }
 
     async fn handle_request(&mut self, request: MCPRequest) -> MCPResponse {
@@ -224,6 +289,47 @@ impl RustAnalyzerMCPServer {
                     data: None,
                 },
             },
+        }
+    }
+}
+
+/// Merged stream of the signals that request server shutdown.
+///
+/// SIGINT and SIGTERM on Unix, Ctrl+C events elsewhere.
+struct ShutdownSignal {
+    #[cfg(unix)]
+    sigint: tokio::signal::unix::Signal,
+    #[cfg(unix)]
+    sigterm: tokio::signal::unix::Signal,
+}
+
+impl ShutdownSignal {
+    fn new() -> Result<Self> {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+
+            Ok(Self {
+                sigint: signal(SignalKind::interrupt())?,
+                sigterm: signal(SignalKind::terminate())?,
+            })
+        }
+        #[cfg(not(unix))]
+        Ok(Self {})
+    }
+
+    /// Completes when the next shutdown signal arrives. Cancellation-safe.
+    async fn recv(&mut self) {
+        #[cfg(unix)]
+        {
+            tokio::select! {
+                _ = self.sigint.recv() => {}
+                _ = self.sigterm.recv() => {}
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
         }
     }
 }

--- a/test-support/src/ipc/client.rs
+++ b/test-support/src/ipc/client.rs
@@ -101,7 +101,14 @@ impl IpcClient {
 
         let binary = binary_path;
 
-        // Start the server in background
+        // Start the server in background, keeping its stderr in a log file next to the socket
+        // for post-mortem debugging. Append so racing daemon generations don't truncate each
+        // other's logs.
+        let log_path = sock_path.with_extension("log");
+        let log_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)?;
         Command::new(&binary)
             .arg("--workspace")
             .arg(workspace_path.to_str().unwrap())
@@ -109,7 +116,7 @@ impl IpcClient {
             .arg(project_type)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::from(log_file))
             .spawn()?;
 
         // Wait for server to start
@@ -127,9 +134,12 @@ impl IpcClient {
             }
 
             attempts += 1;
-            if attempts > 50 {
+            // The server only binds its socket once rust-analyzer is fully initialized, which
+            // can take well over 5 seconds on a cold start, so be patient.
+            if attempts > 600 {
                 return Err(anyhow::anyhow!(
-                    "Failed to connect to MCP server after starting"
+                    "Failed to connect to MCP server after starting; see {}",
+                    log_path.display()
                 ));
             }
 

--- a/test-support/src/ipc/server.rs
+++ b/test-support/src/ipc/server.rs
@@ -3,11 +3,11 @@ use serde_json::{json, Value};
 use std::{
     fs,
     io::{BufRead, BufReader, Write},
-    os::unix::net::UnixListener,
+    os::unix::net::{UnixListener, UnixStream},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::{ChildStdin, ChildStdout, Command, Stdio},
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     thread,
@@ -18,8 +18,23 @@ use std::{
 pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
     let socket_path = socket_path(project_type);
 
-    // Remove old socket if exists
-    let _ = fs::remove_file(&socket_path);
+    // Bind before the expensive rust-analyzer startup: the bound socket is what arbitrates
+    // between daemons racing to serve the same project type. Losers exit quietly, and clients'
+    // connect attempts simply queue in the backlog until the accept loop starts.
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            if UnixStream::connect(&socket_path).is_ok() {
+                // Another daemon already serves this project type.
+                return Ok(());
+            }
+            // Stale socket left behind by a dead daemon.
+            fs::remove_file(&socket_path)?;
+            UnixListener::bind(&socket_path)?
+        }
+        Err(e) => return Err(e.into()),
+    };
+    eprintln!("MCP server listening on {:?}", socket_path);
 
     // Start rust-analyzer process
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
@@ -36,8 +51,17 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
         return Err(anyhow::anyhow!("rust-analyzer-mcp binary not found"));
     };
 
+    // Isolate cargo state per project type: several daemons (and other tests) share the same
+    // workspace, and serializing on one target-directory lock starves them into LSP timeouts on
+    // slow CI runners.
+    let isolation_dir = std::env::temp_dir().join(format!("rust-analyzer-mcp-ipc-{project_type}"));
+    fs::create_dir_all(isolation_dir.join("target"))?;
+    fs::create_dir_all(isolation_dir.join("cache"))?;
+
     let mut rust_analyzer = Command::new(&binary)
         .arg(workspace_path.to_str().unwrap())
+        .env("CARGO_TARGET_DIR", isolation_dir.join("target"))
+        .env("XDG_CACHE_HOME", isolation_dir.join("cache"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -88,17 +112,17 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
     // Wait for rust-analyzer to be ready
     wait_for_ready(&mut stdin, &mut stdout, workspace_path)?;
 
-    // Create Unix socket listener
-    let listener = UnixListener::bind(&socket_path)?;
-    eprintln!("MCP server listening on {:?}", socket_path);
-
     let last_activity = Arc::new(Mutex::new(Instant::now()));
     let shutdown = Arc::new(AtomicBool::new(false));
     let request_id = Arc::new(AtomicU64::new(100)); // Start at 100 to avoid conflicts
+    let pipes = Arc::new(Mutex::new((stdin, stdout)));
+    let active_clients = Arc::new(AtomicUsize::new(0));
 
-    // Spawn idle timeout checker
+    // Spawn idle timeout checker. Only shut down while no client is connected, so a slow
+    // in-flight request or a briefly quiet client cannot get the server killed under them.
     let timeout_activity = last_activity.clone();
     let timeout_shutdown = shutdown.clone();
+    let timeout_active = active_clients.clone();
     thread::spawn(move || loop {
         thread::sleep(Duration::from_secs(1));
 
@@ -107,7 +131,7 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
         }
 
         let last = timeout_activity.lock().unwrap();
-        if last.elapsed() > Duration::from_secs(15) {
+        if last.elapsed() > Duration::from_secs(15) && timeout_active.load(Ordering::SeqCst) == 0 {
             eprintln!("Server idle for 15 seconds, shutting down");
             timeout_shutdown.store(true, Ordering::SeqCst);
             break;
@@ -120,52 +144,26 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
         listener.set_nonblocking(true)?;
 
         match listener.accept() {
-            Ok((mut stream, _)) => {
+            Ok((stream, _)) => {
                 // Update last activity
                 *last_activity.lock().unwrap() = Instant::now();
 
-                // Handle client connection
-                let mut stream_reader = BufReader::new(stream.try_clone()?);
-
-                loop {
-                    let mut request_line = String::new();
-                    let bytes = stream_reader.read_line(&mut request_line)?;
-
-                    if bytes == 0 {
-                        break; // Client disconnected
+                // Handle each client on its own thread: a client keeps its connection open for
+                // as long as it lives, so serving it inline would starve every later client.
+                let pipes = Arc::clone(&pipes);
+                let last_activity = Arc::clone(&last_activity);
+                let request_id = Arc::clone(&request_id);
+                let shutdown = Arc::clone(&shutdown);
+                let active_clients = Arc::clone(&active_clients);
+                active_clients.fetch_add(1, Ordering::SeqCst);
+                thread::spawn(move || {
+                    if let Err(e) =
+                        handle_client(stream, pipes, last_activity, request_id, &shutdown)
+                    {
+                        eprintln!("Client connection error: {}", e);
                     }
-
-                    // Parse request
-                    let request: Value = serde_json::from_str(&request_line)?;
-
-                    // Forward to rust-analyzer
-                    let id = request_id.fetch_add(1, Ordering::SeqCst);
-                    let mut forward_request = json!({
-                        "jsonrpc": "2.0",
-                        "id": id,
-                        "method": request["method"],
-                    });
-
-                    if let Some(params) = request.get("params") {
-                        forward_request["params"] = params.clone();
-                    }
-
-                    let forward_str = serde_json::to_string(&forward_request)?;
-                    stdin.write_all(forward_str.as_bytes())?;
-                    stdin.write_all(b"\n")?;
-                    stdin.flush()?;
-
-                    // Read response from rust-analyzer
-                    let mut response_line = String::new();
-                    stdout.read_line(&mut response_line)?;
-
-                    // Forward response to client
-                    stream.write_all(response_line.as_bytes())?;
-                    stream.flush()?;
-
-                    // Update activity
-                    *last_activity.lock().unwrap() = Instant::now();
-                }
+                    active_clients.fetch_sub(1, Ordering::SeqCst);
+                });
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 // No connection, check if we should shutdown
@@ -178,12 +176,101 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
         }
     }
 
-    // Cleanup
-    let _ = rust_analyzer.kill();
+    // Cleanup. Remove the socket first so a retrying client spawns a fresh daemon instead of
+    // reaching this dying one.
     let _ = fs::remove_file(&socket_path);
+    let _ = rust_analyzer.kill();
     eprintln!("MCP server shutdown");
 
     Ok(())
+}
+
+/// Serve one client connection until it disconnects.
+fn handle_client(
+    mut stream: UnixStream,
+    pipes: Arc<Mutex<(ChildStdin, BufReader<ChildStdout>)>>,
+    last_activity: Arc<Mutex<Instant>>,
+    request_id: Arc<AtomicU64>,
+    shutdown: &AtomicBool,
+) -> Result<()> {
+    let mut stream_reader = BufReader::new(stream.try_clone()?);
+
+    loop {
+        let mut request_line = String::new();
+        let bytes = stream_reader.read_line(&mut request_line)?;
+
+        if bytes == 0 {
+            return Ok(()); // Client disconnected.
+        }
+
+        // Update last activity.
+        *last_activity.lock().unwrap() = Instant::now();
+
+        // Parse request.
+        let request: Value = serde_json::from_str(&request_line)?;
+
+        // Refuse requests the MCP server would not answer, instead of wedging the shared pipe
+        // waiting for a response that never comes.
+        if !request["method"].is_string() {
+            let error = json!({
+                "jsonrpc": "2.0",
+                "id": request["id"],
+                "error": { "code": -32600, "message": "Invalid request: missing method" }
+            });
+            stream.write_all(serde_json::to_string(&error)?.as_bytes())?;
+            stream.write_all(b"\n")?;
+            stream.flush()?;
+            continue;
+        }
+
+        // Forward to rust-analyzer.
+        let id = request_id.fetch_add(1, Ordering::SeqCst);
+        let mut forward_request = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": request["method"],
+        });
+
+        if let Some(params) = request.get("params") {
+            forward_request["params"] = params.clone();
+        }
+
+        let forward_str = serde_json::to_string(&forward_request)?;
+
+        // All clients share the single rust-analyzer-mcp pipe, so the request write and the
+        // response read must stay paired under one critical section.
+        let mut response_line = String::new();
+        let forwarded = {
+            let mut pipes = pipes.lock().unwrap();
+            let (stdin, stdout) = &mut *pipes;
+            stdin
+                .write_all(forward_str.as_bytes())
+                .and_then(|_| stdin.write_all(b"\n"))
+                .and_then(|_| stdin.flush())
+                .and_then(|_| stdout.read_line(&mut response_line))
+        };
+
+        // A pipe failure or EOF means the MCP server is gone; shut the whole IPC server down so
+        // it cannot linger as a zombie accepting clients it can no longer serve.
+        match forwarded {
+            Ok(0) => {
+                shutdown.store(true, Ordering::SeqCst);
+                anyhow::bail!("MCP server closed its stdout");
+            }
+            Err(e) => {
+                shutdown.store(true, Ordering::SeqCst);
+                return Err(anyhow::anyhow!("MCP server pipe error: {}", e));
+            }
+            Ok(_) => {}
+        }
+
+        // Forward response to client.
+        stream.write_all(response_line.as_bytes())?;
+        stream.flush()?;
+
+        // Update activity.
+        *last_activity.lock().unwrap() = Instant::now();
+    }
 }
 
 fn wait_for_ready(
@@ -197,7 +284,9 @@ fn wait_for_ready(
     }
 
     let start = Instant::now();
-    let timeout = Duration::from_secs(10);
+    // Cold rust-analyzer starts routinely exceed 10 seconds in CI, especially with several
+    // instances contending for the same target directory.
+    let timeout = Duration::from_secs(60);
     let mut request_id = 10;
 
     loop {

--- a/tests/integration/shared_test.rs
+++ b/tests/integration/shared_test.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use serde_json::json;
-use test_support::SharedMCPClient;
+use test_support::IpcClient;
 
 #[tokio::test]
 async fn test_shared_singleton() -> Result<()> {
     // Create two clients for the same project - use unique ID for this test
-    let client1 = SharedMCPClient::get_or_create("test-project-singleton").await?;
-    let client2 = SharedMCPClient::get_or_create("test-project-singleton").await?;
+    let mut client1 = IpcClient::get_or_create("test-project-singleton").await?;
+    let mut client2 = IpcClient::get_or_create("test-project-singleton").await?;
 
     // Both should work
     let lib_path = client1.workspace_path().join("src/lib.rs");
@@ -38,27 +38,30 @@ async fn test_shared_singleton() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
 async fn test_shared_concurrent() -> Result<()> {
     use futures::future::join_all;
 
-    // Create multiple clients concurrently - use unique ID for this test
+    // Create multiple clients concurrently - use unique ID for this test. The clients do
+    // blocking I/O, so each task needs its own worker thread to actually overlap.
     let tasks: Vec<_> = (0..5)
-        .map(|i| async move {
-            let client = SharedMCPClient::get_or_create("test-project-concurrent").await?;
-            let lib_path = client.workspace_path().join("src/lib.rs");
+        .map(|i| {
+            tokio::spawn(async move {
+                let mut client = IpcClient::get_or_create("test-project-concurrent").await?;
+                let lib_path = client.workspace_path().join("src/lib.rs");
 
-            let response = client
-                .call_tool(
-                    "rust_analyzer_symbols",
-                    json!({
-                        "file_path": lib_path.to_str().unwrap()
-                    }),
-                )
-                .await?;
+                let response = client
+                    .call_tool(
+                        "rust_analyzer_symbols",
+                        json!({
+                            "file_path": lib_path.to_str().unwrap()
+                        }),
+                    )
+                    .await?;
 
-            println!("Client {} got response", i);
-            Ok::<_, anyhow::Error>(response)
+                println!("Client {} got response", i);
+                Ok::<_, anyhow::Error>(response)
+            })
         })
         .collect();
 
@@ -66,7 +69,7 @@ async fn test_shared_concurrent() -> Result<()> {
 
     // All should succeed
     for result in results {
-        assert!(result?.get("content").is_some());
+        assert!(result??.get("content").is_some());
     }
 
     println!("✓ Concurrent access works!");

--- a/tests/integration/shutdown.rs
+++ b/tests/integration/shutdown.rs
@@ -1,0 +1,192 @@
+use anyhow::Result;
+use serde_json::{json, Value};
+use std::{ffi::OsStr, process::Stdio, time::Duration};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, ChildStdin, ChildStdout, Command},
+    time::timeout,
+};
+
+/// How long the server gets to exit after a shutdown trigger.
+///
+/// Comfortably covers the server's own graceful-shutdown timeout, after which it force-kills
+/// rust-analyzer.
+const EXIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long to wait for a response line from the server.
+///
+/// Generous because a first tool call cold-starts rust-analyzer, which is slow in CI.
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[cfg(unix)]
+#[tokio::test]
+async fn exits_on_sigint() -> Result<()> {
+    assert_signal_exit("-INT").await
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn exits_on_sigterm() -> Result<()> {
+    assert_signal_exit("-TERM").await
+}
+
+#[tokio::test]
+async fn exits_on_stdin_close() -> Result<()> {
+    let mut server = Server::spawn(std::env::temp_dir()).await?;
+
+    drop(server.stdin.take());
+    let (status, stderr) = server.wait_for_exit("stdin EOF").await?;
+    assert!(
+        status.success(),
+        "expected graceful exit, got {status}:\n{stderr}"
+    );
+    Ok(())
+}
+
+/// A signal must terminate the server even once rust-analyzer is running, going through the
+/// graceful cleanup path (with its force-kill fallback) rather than relying on a stdin EOF.
+#[cfg(unix)]
+#[tokio::test]
+async fn exits_on_signal_with_live_rust_analyzer() -> Result<()> {
+    let workspace = concat!(env!("CARGO_MANIFEST_DIR"), "/test-project");
+    let mut server = Server::spawn(workspace).await?;
+
+    // The first tool call spawns and initializes rust-analyzer inside the server.
+    let response = server
+        .request(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "rust_analyzer_symbols",
+                "arguments": { "file_path": "src/main.rs" }
+            }
+        }))
+        .await?;
+    anyhow::ensure!(
+        response.get("result").is_some(),
+        "tool call failed, rust-analyzer is not running: {response}"
+    );
+
+    server.signal("-TERM")?;
+    let (status, stderr) = server.wait_for_exit("SIGTERM").await?;
+    assert!(
+        status.success(),
+        "expected graceful exit, got {status}:\n{stderr}"
+    );
+    // A single signal must go through the graceful LSP handshake, not the force-kill paths.
+    assert!(
+        stderr.contains("Shutting down"),
+        "cleanup never ran:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Graceful shutdown timed out")
+            && !stderr.contains("another shutdown signal"),
+        "graceful LSP handshake was skipped:\n{stderr}"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn assert_signal_exit(signal: &str) -> Result<()> {
+    // Keep the write end of stdin open: the signal must suffice on its own, without an EOF. This
+    // mirrors both an interactive Ctrl+C and an MCP host that signals before closing the pipe.
+    let server = Server::spawn(std::env::temp_dir()).await?;
+
+    server.signal(signal)?;
+    let (status, stderr) = server.wait_for_exit(signal).await?;
+    assert!(
+        status.success(),
+        "expected graceful exit, got {status}:\n{stderr}"
+    );
+    Ok(())
+}
+
+struct Server {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+    stderr_file: tempfile::NamedTempFile,
+    /// Keeps the isolated cargo target/cache directories alive for the server's lifetime.
+    _isolation_dir: tempfile::TempDir,
+}
+
+impl Server {
+    /// Spawns the server and waits until it answers an `initialize` request: the response proves
+    /// the signal handlers are installed, since the server installs them before reading requests.
+    async fn spawn(workspace: impl AsRef<OsStr>) -> Result<Self> {
+        // Capture stderr to a file so tests can assert on the server's shutdown logs.
+        let stderr_file = tempfile::NamedTempFile::new()?;
+        // Isolate cargo state so a spawned rust-analyzer does not serialize on the shared
+        // workspace's target-directory lock with the other tests.
+        let isolation_dir = tempfile::tempdir()?;
+        let mut child = Command::new(env!("CARGO_BIN_EXE_rust-analyzer-mcp"))
+            .arg(workspace)
+            .env("CARGO_TARGET_DIR", isolation_dir.path().join("target"))
+            .env("XDG_CACHE_HOME", isolation_dir.path().join("cache"))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::from(stderr_file.reopen()?))
+            .spawn()?;
+        let stdin = child.stdin.take().expect("stdin is piped");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout is piped"));
+
+        let mut server = Self {
+            child,
+            stdin: Some(stdin),
+            stdout,
+            stderr_file,
+            _isolation_dir: isolation_dir,
+        };
+        server
+            .request(json!({"jsonrpc": "2.0", "id": 1, "method": "initialize"}))
+            .await?;
+        Ok(server)
+    }
+
+    async fn request(&mut self, request: Value) -> Result<Value> {
+        let mut line = serde_json::to_string(&request)?;
+        line.push('\n');
+        let stdin = self.stdin.as_mut().expect("stdin already closed");
+        stdin.write_all(line.as_bytes()).await?;
+        stdin.flush().await?;
+
+        let mut response = String::new();
+        timeout(RESPONSE_TIMEOUT, self.stdout.read_line(&mut response)).await??;
+        Ok(serde_json::from_str(&response)?)
+    }
+
+    #[cfg(unix)]
+    fn signal(&self, signal: &str) -> Result<()> {
+        let Some(pid) = self.child.id() else {
+            anyhow::bail!("server exited before the signal was sent");
+        };
+        let status = std::process::Command::new("kill")
+            .arg(signal)
+            .arg(pid.to_string())
+            .status()?;
+        anyhow::ensure!(status.success(), "kill {signal} {pid} failed");
+        Ok(())
+    }
+
+    /// Waits for the server to exit and returns its status and captured stderr.
+    async fn wait_for_exit(mut self, trigger: &str) -> Result<(std::process::ExitStatus, String)> {
+        let status = match timeout(EXIT_TIMEOUT, self.child.wait()).await {
+            Ok(status) => status?,
+            Err(_) => {
+                let _ = self.child.start_kill();
+                let _ = self.child.wait().await;
+                anyhow::bail!(
+                    "server still running {EXIT_TIMEOUT:?} after {trigger}:\n{}",
+                    self.stderr()
+                );
+            }
+        };
+        let stderr = self.stderr();
+        Ok((status, stderr))
+    }
+
+    fn stderr(&self) -> String {
+        std::fs::read_to_string(self.stderr_file.path()).unwrap_or_default()
+    }
+}

--- a/tests/integration/shutdown.rs
+++ b/tests/integration/shutdown.rs
@@ -30,6 +30,12 @@ async fn exits_on_sigterm() -> Result<()> {
     assert_signal_exit("-TERM").await
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn exits_on_sighup() -> Result<()> {
+    assert_signal_exit("-HUP").await
+}
+
 #[tokio::test]
 async fn exits_on_stdin_close() -> Result<()> {
     let mut server = Server::spawn(std::env::temp_dir()).await?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 mod integration {
     mod diagnostics;
     mod mcp_server_test;
+    mod shared_test;
     mod shutdown;
-    // mod shared_test;  // This test file doesn't exist yet
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 mod integration {
     mod diagnostics;
     mod mcp_server_test;
+    mod shutdown;
     // mod shared_test;  // This test file doesn't exist yet
 }


### PR DESCRIPTION
The server never exited on Ctrl+C or SIGTERM unless its stdin also reached EOF: the signal task only flipped a flag the blocked read loop never re-checked, tokio's installed handler swallowed every follow-up signal, and even with the loop fixed the runtime drop waited forever on the uncancellable blocking stdin read. This left orphaned `rust-analyzer-mcp` processes behind whenever an MCP host signalled without closing the pipe.

This PR makes shutdown signal-driven end to end: persistent SIGINT/SIGTERM/SIGHUP streams (Ctrl+C/console-close on Windows) raced against both the stdin read and in-flight request handling via biased `select!`, a bounded graceful LSP handshake with a force-kill fallback, `shutdown_background()` so the parked stdin read cannot hold the process hostage, and cleanup that runs on stdout errors while still reporting them through the exit status.

Along the way: `--help`/`--version`/argument validation (previously `--help` started a server with workspace `--help`), the initialize response now reports the real crate version, and the dormant shared IPC client tests are revived — ported to `IpcClient` and their daemon fixed to serve clients concurrently instead of deadlocking the second client. New integration tests cover SIGINT/SIGTERM/SIGHUP/stdin-EOF shutdown, including the graceful-handshake path with a live rust-analyzer.

Generated by Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197e2KbPmQpwuFsiiz9iGYa