### PR TITLE
💚 Fix test_shared_concurrent flake that broke CI on main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,4 +58,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build and Test
         run: |
-          cargo test --locked --release --all-features
+          cargo test --locked --workspace --release --all-features

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -187,22 +187,36 @@ impl RustAnalyzerClient {
 
         info!("Sending LSP request: {} with params: {:?}", method, params);
 
+        // Register the response channel before writing the request: a response arriving
+        // between the write and the registration would be dropped by the reader task,
+        // turning into a spurious request timeout.
+        let (tx, rx) = oneshot::channel();
+        let pending_requests = self.pending_requests.clone();
+        pending_requests.lock().await.insert(id, tx);
+
         let Some(stdin) = &mut self.stdin else {
+            pending_requests.lock().await.remove(&id);
             return Err(anyhow!("No stdin available"));
         };
 
-        stdin.write_all(message.as_bytes()).await?;
-        stdin.flush().await?;
-
-        // Set up response channel.
-        let (tx, rx) = oneshot::channel();
-        self.pending_requests.lock().await.insert(id, tx);
+        let mut written = stdin.write_all(message.as_bytes()).await;
+        if written.is_ok() {
+            written = stdin.flush().await;
+        }
+        if let Err(e) = written {
+            pending_requests.lock().await.remove(&id);
+            return Err(e.into());
+        }
 
         // Wait for response with timeout.
-        tokio::time::timeout(Duration::from_secs(LSP_REQUEST_TIMEOUT_SECS), rx)
-            .await
-            .map_err(|_| anyhow!("Request timeout"))?
-            .map_err(|_| anyhow!("Request cancelled"))
+        match tokio::time::timeout(Duration::from_secs(LSP_REQUEST_TIMEOUT_SECS), rx).await {
+            Ok(response) => response.map_err(|_| anyhow!("Request cancelled")),
+            Err(_) => {
+                // Unregister so an abandoned request cannot leak its pending entry.
+                pending_requests.lock().await.remove(&id);
+                Err(anyhow!("Request timeout"))
+            }
+        }
     }
 
     async fn initialize(&mut self) -> Result<()> {

--- a/test-support/src/ipc/client.rs
+++ b/test-support/src/ipc/client.rs
@@ -12,6 +12,9 @@ use std::{
 
 use super::server::socket_path;
 
+/// Maximum attempts for a tool call whose previous attempts failed on a transient timeout.
+const TOOL_CALL_ATTEMPTS: u32 = 3;
+
 /// Client that connects to the IPC MCP server
 pub struct IpcClient {
     stream: UnixStream,
@@ -21,6 +24,18 @@ pub struct IpcClient {
 }
 
 impl IpcClient {
+    /// Connect to a server listening on the given socket path.
+    fn connect(sock_path: &Path, workspace_path: PathBuf) -> Result<Self> {
+        let stream = UnixStream::connect(sock_path)?;
+        let reader = BufReader::new(stream.try_clone()?);
+        Ok(Self {
+            stream,
+            reader,
+            request_id: AtomicU64::new(1),
+            workspace_path,
+        })
+    }
+
     /// Connect to or start an IPC MCP server
     pub async fn get_or_create(project_type: &str) -> Result<Self> {
         // Map project types to workspace paths
@@ -41,15 +56,9 @@ impl IpcClient {
         let sock_path = socket_path(project_type);
 
         // Try to connect to existing server
-        if let Ok(stream) = UnixStream::connect(&sock_path) {
+        if let Ok(client) = Self::connect(&sock_path, workspace_path.clone()) {
             eprintln!("Connected to existing MCP server for {}", project_type);
-            let reader = BufReader::new(stream.try_clone()?);
-            return Ok(Self {
-                stream,
-                reader,
-                request_id: AtomicU64::new(1),
-                workspace_path,
-            });
+            return Ok(client);
         }
 
         // Server not running, start it
@@ -122,15 +131,9 @@ impl IpcClient {
         // Wait for server to start
         let mut attempts = 0;
         loop {
-            if let Ok(stream) = UnixStream::connect(&sock_path) {
+            if let Ok(client) = Self::connect(&sock_path, workspace_path.clone()) {
                 eprintln!("Connected to new MCP server for {}", project_type);
-                let reader = BufReader::new(stream.try_clone()?);
-                return Ok(Self {
-                    stream,
-                    reader,
-                    request_id: AtomicU64::new(1),
-                    workspace_path,
-                });
+                return Ok(client);
             }
 
             attempts += 1;
@@ -173,9 +176,22 @@ impl IpcClient {
 
         let response: Value = serde_json::from_str(&line)?;
 
+        // The connection is lockstep (one request in flight), so a mismatched id means the
+        // shared daemon pipe lost sync; failing fast beats returning someone else's answer.
+        if response["id"] != json!(id) {
+            return Err(anyhow::anyhow!(
+                "Response id {} does not match request id {}",
+                response["id"],
+                id
+            ));
+        }
+
         // Extract result or error
         if let Some(error) = response.get("error") {
-            return Err(anyhow::anyhow!("MCP error: {}", error));
+            return Err(anyhow::Error::new(McpError {
+                code: error["code"].as_i64().unwrap_or_default(),
+                message: error["message"].as_str().unwrap_or_default().to_string(),
+            }));
         }
 
         Ok(response.get("result").cloned().unwrap_or(json!(null)))
@@ -183,14 +199,32 @@ impl IpcClient {
 
     /// Call a tool on the server
     pub async fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value> {
-        self.send_request(
-            "tools/call",
-            Some(json!({
-                "name": name,
-                "arguments": arguments
-            })),
-        )
-        .await
+        let params = json!({
+            "name": name,
+            "arguments": arguments
+        });
+
+        // The MCP server bounds every LSP request with its own timeout, which can fire even
+        // though rust-analyzer is healthy when a loaded machine (CI especially) starves it of
+        // CPU. Such timeouts are transient, so retry a few times before declaring failure.
+        let mut attempt = 1;
+        loop {
+            match self.send_request("tools/call", Some(params.clone())).await {
+                Err(e)
+                    if attempt < TOOL_CALL_ATTEMPTS
+                        && e.downcast_ref::<McpError>()
+                            .is_some_and(McpError::is_transient_timeout) =>
+                {
+                    eprintln!(
+                        "Tool call {name} timed out (attempt {attempt}/{TOOL_CALL_ATTEMPTS}); \
+                         retrying"
+                    );
+                    tokio::time::sleep(crate::timeouts::tool_retry_delay() * attempt).await;
+                    attempt += 1;
+                }
+                result => return result,
+            }
+        }
     }
 
     /// Get the workspace path
@@ -203,5 +237,159 @@ impl Drop for IpcClient {
     fn drop(&mut self) {
         // Just disconnect, server will auto-shutdown after 15 seconds
         let _ = self.stream.shutdown(std::net::Shutdown::Both);
+    }
+}
+
+/// A JSON-RPC error response from the MCP server.
+#[derive(Debug)]
+pub struct McpError {
+    pub code: i64,
+    pub message: String,
+}
+
+impl McpError {
+    /// Whether this is the MCP server's LSP request timeout, which is transient under load.
+    fn is_transient_timeout(&self) -> bool {
+        self.code == -1 && self.message == "Request timeout"
+    }
+}
+
+impl std::fmt::Display for McpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MCP error {}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for McpError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+
+    /// Spawn a fake daemon that answers each incoming request line with the next canned
+    /// response (echoing the request id back unless the response carries its own) until the
+    /// client disconnects, then returns the requests it served.
+    fn fake_daemon(
+        listener: UnixListener,
+        responses: Vec<Value>,
+    ) -> thread::JoinHandle<Vec<Value>> {
+        thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut writer = stream;
+            let mut served = Vec::new();
+            for mut response in responses {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap() == 0 {
+                    break;
+                }
+                let request: Value = serde_json::from_str(&line).unwrap();
+                if response.get("id").is_none() {
+                    response["id"] = request["id"].clone();
+                }
+                writer
+                    .write_all(serde_json::to_string(&response).unwrap().as_bytes())
+                    .unwrap();
+                writer.write_all(b"\n").unwrap();
+                writer.flush().unwrap();
+                served.push(request);
+            }
+            served
+        })
+    }
+
+    fn timeout_error() -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "error": { "code": -1, "message": "Request timeout", "data": null }
+        })
+    }
+
+    fn fake_client(
+        dir: &Path,
+        responses: Vec<Value>,
+    ) -> (IpcClient, thread::JoinHandle<Vec<Value>>) {
+        let sock_path = dir.join("daemon.sock");
+        let listener = UnixListener::bind(&sock_path).unwrap();
+        let server = fake_daemon(listener, responses);
+        let client = IpcClient::connect(&sock_path, dir.to_path_buf()).unwrap();
+        (client, server)
+    }
+
+    #[tokio::test]
+    async fn call_tool_retries_transient_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let success = json!({
+            "jsonrpc": "2.0",
+            "result": { "content": [{ "type": "text", "text": "[]" }] }
+        });
+        let (mut client, server) = fake_client(dir.path(), vec![timeout_error(), success]);
+
+        let response = client
+            .call_tool("rust_analyzer_symbols", json!({"file_path": "src/lib.rs"}))
+            .await
+            .unwrap();
+        assert!(response.get("content").is_some());
+        drop(client);
+
+        // The retry must be a fresh request with a new id but an unchanged payload.
+        let served = server.join().unwrap();
+        assert_eq!(served.len(), 2);
+        assert_ne!(served[0]["id"], served[1]["id"]);
+        assert_eq!(served[0]["method"], served[1]["method"]);
+        assert_eq!(served[0]["params"], served[1]["params"]);
+    }
+
+    #[tokio::test]
+    async fn call_tool_gives_up_after_repeated_timeouts() {
+        let dir = tempfile::tempdir().unwrap();
+        let responses = (0..TOOL_CALL_ATTEMPTS).map(|_| timeout_error()).collect();
+        let (mut client, server) = fake_client(dir.path(), responses);
+
+        let error = client
+            .call_tool("rust_analyzer_symbols", json!({"file_path": "src/lib.rs"}))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("Request timeout"));
+        drop(client);
+        assert_eq!(server.join().unwrap().len(), TOOL_CALL_ATTEMPTS as usize);
+    }
+
+    #[tokio::test]
+    async fn call_tool_does_not_retry_other_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let invalid = json!({
+            "jsonrpc": "2.0",
+            "error": { "code": -32602, "message": "Missing tool name", "data": null }
+        });
+        let (mut client, server) = fake_client(dir.path(), vec![invalid]);
+
+        let error = client
+            .call_tool("rust_analyzer_symbols", json!({"file_path": "src/lib.rs"}))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("Missing tool name"));
+        drop(client);
+        assert_eq!(server.join().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn send_request_rejects_mismatched_response_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let desynced = json!({
+            "jsonrpc": "2.0",
+            "id": 999,
+            "result": { "content": [] }
+        });
+        let (mut client, server) = fake_client(dir.path(), vec![desynced]);
+
+        let error = client
+            .call_tool("rust_analyzer_symbols", json!({"file_path": "src/lib.rs"}))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("does not match request id"));
+        drop(client);
+        assert_eq!(server.join().unwrap().len(), 1);
     }
 }

--- a/test-support/src/ipc/server.rs
+++ b/test-support/src/ipc/server.rs
@@ -14,6 +14,10 @@ use std::{
     time::{Duration, Instant},
 };
 
+/// Shared handle to the MCP server's stdio, keeping each request write paired with its
+/// response read.
+type SharedPipes = Arc<Mutex<(ChildStdin, BufReader<ChildStdout>)>>;
+
 /// Start a standalone MCP server process that listens on Unix socket
 pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
     let socket_path = socket_path(project_type);
@@ -188,7 +192,7 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
 /// Serve one client connection until it disconnects.
 fn handle_client(
     mut stream: UnixStream,
-    pipes: Arc<Mutex<(ChildStdin, BufReader<ChildStdout>)>>,
+    pipes: SharedPipes,
     last_activity: Arc<Mutex<Instant>>,
     request_id: Arc<AtomicU64>,
     shutdown: &AtomicBool,
@@ -264,8 +268,34 @@ fn handle_client(
             Ok(_) => {}
         }
 
-        // Forward response to client.
-        stream.write_all(response_line.as_bytes())?;
+        // An unparseable frame means the shared pipe is corrupt; every client on it would be
+        // affected, so retire the whole daemon rather than just this connection.
+        let mut response: Value = match serde_json::from_str(&response_line) {
+            Ok(response) => response,
+            Err(e) => {
+                shutdown.store(true, Ordering::SeqCst);
+                anyhow::bail!("Unparseable MCP response on the shared pipe: {e}");
+            }
+        };
+
+        // Refuse to relabel a frame that is not the response to the request just forwarded: a
+        // stale or unsolicited frame means the pipe is desynced, and relabeling it would hand
+        // this client (and everyone after it) someone else's answers.
+        if response["id"] != json!(id) {
+            shutdown.store(true, Ordering::SeqCst);
+            anyhow::bail!(
+                "MCP response id {} does not match forwarded id {}; shutting down desynced pipe",
+                response["id"],
+                id
+            );
+        }
+
+        // Forward the response to the client with its original request id restored: the daemon
+        // rewrites ids on the shared pipe, and the client correlates responses by the id it
+        // sent.
+        response["id"] = request["id"].clone();
+        stream.write_all(serde_json::to_string(&response)?.as_bytes())?;
+        stream.write_all(b"\n")?;
         stream.flush()?;
 
         // Update activity.
@@ -360,4 +390,95 @@ pub fn socket_path(project_type: &str) -> PathBuf {
     let socket_dir = std::env::temp_dir().join("rust-analyzer-mcp-sockets");
     let _ = fs::create_dir_all(&socket_dir);
     socket_dir.join(format!("{}.sock", project_type))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{io::Read, process::Child};
+
+    /// Spawn a shell standing in for the MCP server on the shared pipe: `script` reads request
+    /// lines on stdin and writes response lines on stdout.
+    fn fake_mcp_server(script: &str) -> (Child, SharedPipes) {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        (child, Arc::new(Mutex::new((stdin, stdout))))
+    }
+
+    /// Run one request through `handle_client` against the given fake MCP server script and
+    /// return the handler's result, the shutdown flag, and what the client received.
+    fn forward_one_request(script: &str) -> (Result<()>, bool, String) {
+        let (mut child, pipes) = fake_mcp_server(script);
+        let (daemon_side, client_side) = UnixStream::pair().unwrap();
+
+        // Write the request up front and close the write half so the handler sees a client
+        // that sends one request and disconnects.
+        (&client_side)
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":{}}\n")
+            .unwrap();
+        client_side.shutdown(std::net::Shutdown::Write).unwrap();
+
+        let shutdown = AtomicBool::new(false);
+        let result = handle_client(
+            daemon_side,
+            pipes,
+            Arc::new(Mutex::new(Instant::now())),
+            Arc::new(AtomicU64::new(100)),
+            &shutdown,
+        );
+
+        let mut received = String::new();
+        BufReader::new(client_side)
+            .read_to_string(&mut received)
+            .unwrap();
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        (result, shutdown.load(Ordering::SeqCst), received)
+    }
+
+    #[test]
+    fn restores_client_id_on_forwarded_response() {
+        // The echo server answers with the forwarded request itself, so the response carries
+        // the daemon's rewritten id; the client must get its own id back.
+        let (result, shutdown, received) =
+            forward_one_request(r#"while IFS= read -r line; do printf '%s\n' "$line"; done"#);
+
+        result.unwrap();
+        assert!(!shutdown);
+        let response: Value = serde_json::from_str(&received).unwrap();
+        assert_eq!(response["id"], json!(7));
+    }
+
+    #[test]
+    fn shuts_down_on_desynced_response_id() {
+        // A frame that is not the response to the forwarded request must not be relabeled as
+        // one; the daemon has to treat the pipe as desynced and retire itself.
+        let (result, shutdown, received) = forward_one_request(
+            r#"while IFS= read -r line; do printf '{"jsonrpc":"2.0","id":424242,"result":null}\n'; done"#,
+        );
+
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("does not match forwarded id"));
+        assert!(shutdown);
+        assert!(received.is_empty());
+    }
+
+    #[test]
+    fn shuts_down_on_unparseable_response() {
+        let (result, shutdown, received) =
+            forward_one_request(r#"while IFS= read -r line; do printf 'not json\n'; done"#);
+
+        assert!(result.is_err());
+        assert!(shutdown);
+        assert!(received.is_empty());
+    }
 }


### PR DESCRIPTION
Fixes the CI failure on main introduced by #23 (run [31898222002](https://github.com/zeenix/rust-analyzer-mcp/actions/runs/31898222002)).

## What happened

`test_shared_concurrent` — enabled by #23 — failed on the first main run after the merge with:

```
Error: MCP error: {"code":-1,"data":null,"message":"Request timeout"}
```

The same tree (425bb89) had passed CI on the PR branch, so the failure is load-dependent, not
deterministic.

## Root cause

The MCP server bounds every LSP request at 30 seconds (`LSP_REQUEST_TIMEOUT_SECS`). In the failing
run, `test_workspace_diagnostics` (a cold `cargo check` of the whole workspace) ran in parallel on
the ~2-vCPU runner until one second before the failure; one of the five serialized
`documentSymbol` requests exceeded 30 s inside rust-analyzer, the server returned its timeout
error, and the IPC daemon faithfully forwarded it. The rest of the suite tolerates transient
slowness by polling with a deadline (`wait_for_ready`, `initialize_and_wait`, the diagnostics
tests); `IpcClient` was the one path with no tolerance at all.

An adversarial review of the initial fix also surfaced a second, deterministic source of the same
error: `send_request` in the LSP client wrote the request before registering its response channel,
so a reply landing in that window was silently dropped and manufactured a spurious 30-second
timeout.

## Fix

- The LSP client registers the response channel before writing the request, and unregisters it on
  write failure or timeout so abandoned requests cannot leak pending entries.
- `IpcClient::call_tool` retries the server's exact timeout error (typed `McpError`, code and
  message matched — not a substring check), bounded at 3 attempts with backoff via the existing
  `tool_retry_delay()`. Other errors are not retried.
- Since retries put more than one request id on the wire per call, response correlation is now
  enforced at both hops: the daemon refuses to relabel a frame whose id is not the one it just
  forwarded and retires the desynced pipe instead (likewise for unparseable frames), restores the
  client's original id when forwarding a valid response, and the client rejects mismatched ids — a
  desynced shared pipe fails fast instead of returning someone else's answer.
- Unit tests cover both hops: fake-daemon tests for the client (retry uses a fresh id with an
  unchanged payload, bounded give-up, no-retry-on-other-errors, id-mismatch rejection) and
  forwarding-path tests driving `handle_client` against a shell child standing in for the MCP
  server (id restoration, mismatch shutdown, parse-failure shutdown). TDD: the retry test
  reproduced the exact CI error before the fix.
- CI now runs `cargo test --workspace`, since the root-package invocation never ran the
  test-support crate's own unit tests, including the new ones.

Verified locally with the exact CI invocation (`RUSTFLAGS="-D warnings" cargo test --locked
--workspace --release --all-features`): 51 tests across 10 suites pass; fmt and clippy gates clean.

Generated by Claude Fable 5 (claude-fable-5).
