### PR TITLE
🚑️ Fix rust-analyzer dying on didSave during workspace load, which broke CI on main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,3 +59,13 @@ jobs:
       - name: Build and Test
         run: |
           cargo test --locked --workspace --release --all-features
+      # The test daemons log to these files, rust-analyzer's own stderr included; they are the
+      # only trace of why a daemon's rust-analyzer died.
+      - name: Upload the test daemons' logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-daemon-logs
+          path: /tmp/rust-analyzer-mcp-sockets/*.log*
+          if-no-files-found: ignore
+          retention-days: 14

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
-    process::Stdio,
+    process::{ExitStatus, Stdio},
     sync::Arc,
     time::Duration,
 };
@@ -12,6 +12,7 @@ use tokio::{
     io::{AsyncWriteExt, BufWriter},
     process::{Child, Command},
     sync::{oneshot, watch, Mutex},
+    task::JoinHandle,
 };
 
 use crate::{
@@ -35,6 +36,8 @@ pub struct RustAnalyzerClient {
     pub(super) quiescent: watch::Sender<bool>,
     /// Open documents whose `didSave` has been sent, see [`Self::open_document`].
     pub(super) saved_documents: HashSet<String>,
+    /// The task reading rust-analyzer's stdout; it finishing means rust-analyzer is gone.
+    pub(super) reader: Option<JoinHandle<()>>,
 }
 
 impl RustAnalyzerClient {
@@ -61,6 +64,7 @@ impl RustAnalyzerClient {
             diagnostics: Arc::new(Mutex::new(HashMap::new())),
             quiescent: watch::channel(false).0,
             saved_documents: HashSet::new(),
+            reader: None,
         }
     }
 
@@ -81,7 +85,9 @@ impl RustAnalyzerClient {
         cmd.current_dir(&self.workspace_root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stderr(Stdio::piped())
+            // So that a start failing halfway cannot leave an orphaned rust-analyzer behind.
+            .kill_on_drop(true);
 
         // Pass through isolation environment variables if they're set.
         if let Ok(cache_home) = std::env::var("XDG_CACHE_HOME") {
@@ -113,14 +119,16 @@ impl RustAnalyzerClient {
 
         self.stdin = Some(BufWriter::new(stdin));
 
-        // Start connection handlers.
-        super::connection::start_handlers(
+        // Start connection handlers, with a pending-request map of their own: the reader of an
+        // earlier process fails whatever is left in its map when it finishes.
+        self.pending_requests = Arc::new(Mutex::new(HashMap::new()));
+        self.reader = Some(super::connection::start_handlers(
             stdout,
             stderr,
             Arc::clone(&self.pending_requests),
             Arc::clone(&self.diagnostics),
             self.quiescent.clone(),
-        );
+        ));
 
         self.process = Some(child);
 
@@ -216,9 +224,10 @@ impl RustAnalyzerClient {
             return Err(e.into());
         }
 
-        // Wait for response with timeout.
+        // Wait for response with timeout. The channel only closes unanswered when the reader
+        // task gave up on rust-analyzer's stdout, i.e. rust-analyzer is gone.
         match tokio::time::timeout(Duration::from_secs(LSP_REQUEST_TIMEOUT_SECS), rx).await {
-            Ok(response) => response.map_err(|_| anyhow!("Request cancelled")),
+            Ok(response) => response.map_err(|_| anyhow!("rust-analyzer exited before responding")),
             Err(_) => {
                 // Unregister so an abandoned request cannot leak its pending entry.
                 pending_requests.lock().await.remove(&id);
@@ -406,6 +415,16 @@ impl RustAnalyzerClient {
         self.diagnostics.lock().await.clear();
         self.initialized = false;
     }
+
+    /// Whether rust-analyzer is gone, i.e. its stdout has closed because it exited or is about to.
+    pub fn is_gone(&self) -> bool {
+        self.reader.as_ref().is_some_and(JoinHandle::is_finished)
+    }
+
+    /// The exit status of the rust-analyzer process, if it has exited.
+    pub fn exit_status(&mut self) -> Option<ExitStatus> {
+        self.process.as_mut()?.try_wait().ok().flatten()
+    }
 }
 
 fn find_rust_analyzer() -> Result<PathBuf> {
@@ -471,6 +490,61 @@ mod tests {
         let sent = written(&mut client, &mut child).await;
         assert_eq!(sent.matches("textDocument/didOpen").count(), 1, "{sent}");
         assert_eq!(sent.matches("textDocument/didSave").count(), 1, "{sent}");
+    }
+
+    #[tokio::test]
+    async fn exit_status_reflects_whether_rust_analyzer_is_alive() {
+        let mut client = RustAnalyzerClient::new(PathBuf::from("."));
+        // The shell lives until its stdin closes, then exits with 3.
+        let mut child = Command::new("sh")
+            .args(["-c", "read _; exit 3"])
+            .stdin(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take();
+        client.process = Some(child);
+
+        assert!(client.exit_status().is_none());
+
+        drop(stdin);
+        client.process.as_mut().unwrap().wait().await.unwrap();
+        assert_eq!(
+            client.exit_status().and_then(|status| status.code()),
+            Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn is_gone_once_rust_analyzer_closes_its_stdout() {
+        let mut client = RustAnalyzerClient::new(PathBuf::from("."));
+        let (stdout, rust_analyzer) = tokio::io::duplex(64);
+        client.reader = Some(super::super::connection::start_handlers(
+            stdout,
+            tokio::io::empty(),
+            Arc::clone(&client.pending_requests),
+            Arc::clone(&client.diagnostics),
+            client.quiescent.clone(),
+        ));
+        tokio::task::yield_now().await;
+        assert!(!client.is_gone());
+
+        drop(rust_analyzer);
+        tokio::time::timeout(Duration::from_secs(5), client.reader.as_mut().unwrap())
+            .await
+            .expect("reader must finish once stdout closes")
+            .unwrap();
+        assert!(client.is_gone());
+    }
+
+    #[tokio::test]
+    async fn workspace_diagnostics_fails_once_rust_analyzer_is_gone() {
+        let mut client = RustAnalyzerClient::new(PathBuf::from("."));
+        let mut reader = tokio::spawn(async {});
+        (&mut reader).await.unwrap();
+        client.reader = Some(reader);
+
+        // Must not fall back to an empty, i.e. clean-looking, report.
+        assert!(client.workspace_diagnostics().await.is_err());
     }
 
     /// A client whose "rust-analyzer" is a `cat` process, so that everything the client writes

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -11,7 +11,7 @@ use std::{
 use tokio::{
     io::{AsyncWriteExt, BufWriter},
     process::{Child, Command},
-    sync::{oneshot, Mutex},
+    sync::{oneshot, watch, Mutex},
 };
 
 use crate::{
@@ -30,6 +30,11 @@ pub struct RustAnalyzerClient {
     pub(super) initialized: bool,
     pub(super) open_documents: Arc<Mutex<HashSet<String>>>,
     pub(super) diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
+    /// Whether rust-analyzer last reported itself quiescent, i.e. with no background work such
+    /// as loading the workspace in flight. Fed by its `experimental/serverStatus` notifications.
+    pub(super) quiescent: watch::Sender<bool>,
+    /// Open documents whose `didSave` has been sent, see [`Self::open_document`].
+    pub(super) saved_documents: HashSet<String>,
 }
 
 impl RustAnalyzerClient {
@@ -54,6 +59,8 @@ impl RustAnalyzerClient {
             initialized: false,
             open_documents: Arc::new(Mutex::new(HashSet::new())),
             diagnostics: Arc::new(Mutex::new(HashMap::new())),
+            quiescent: watch::channel(false).0,
+            saved_documents: HashSet::new(),
         }
     }
 
@@ -112,6 +119,7 @@ impl RustAnalyzerClient {
             stderr,
             Arc::clone(&self.pending_requests),
             Arc::clone(&self.diagnostics),
+            self.quiescent.clone(),
         );
 
         self.process = Some(child);
@@ -289,6 +297,11 @@ impl RustAnalyzerClient {
                     "didChangeConfiguration": {
                         "dynamicRegistration": false
                     }
+                },
+                // Opt into `experimental/serverStatus` notifications, which report whether
+                // rust-analyzer is quiescent.
+                "experimental": {
+                    "serverStatusNotification": true
                 }
             }
         });
@@ -306,41 +319,43 @@ impl RustAnalyzerClient {
     }
 
     pub async fn open_document(&mut self, uri: &str, content: &str) -> Result<()> {
-        // Check if document is already open.
-        {
-            let open_docs = self.open_documents.lock().await;
-            if open_docs.contains(uri) {
-                info!("Document already open: {}", uri);
-                return Ok(());
-            }
+        let already_open = self.open_documents.lock().await.contains(uri);
+        if already_open {
+            info!("Document already open: {}", uri);
+        } else {
+            info!("Opening document: {}", uri);
+            let params = json!({
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "rust",
+                    "version": 1,
+                    "text": content
+                }
+            });
+            self.send_notification("textDocument/didOpen", Some(params))
+                .await?;
+
+            self.open_documents.lock().await.insert(uri.to_string());
         }
 
-        // Clear any existing diagnostics for this URI to ensure fresh data.
-        {
-            let mut diag_lock = self.diagnostics.lock().await;
-            diag_lock.remove(uri);
+        // A didSave makes rust-analyzer run cargo check for the document's package. It has to
+        // wait until rust-analyzer is quiescent, though: during a workspace load the freshly
+        // opened document has no source root yet, and rust-analyzer's didSave handler then panics
+        // and takes the whole process down (seen with 1.97 and 1.98). So hold it back while busy
+        // and send it on the document's next use instead; in the meantime the workspace-wide
+        // cargo check rust-analyzer runs on its own once quiescent covers the document anyway.
+        // The flag is only a snapshot, so this narrows the window rather than closing it.
+        if self.saved_documents.contains(uri) {
+            return Ok(());
+        }
+        if !*self.quiescent.borrow() {
+            info!("rust-analyzer is busy, holding back didSave for {}", uri);
+            return Ok(());
         }
 
-        info!("Opening document: {}", uri);
-        let params = json!({
-            "textDocument": {
-                "uri": uri,
-                "languageId": "rust",
-                "version": 1,
-                "text": content
-            }
-        });
-
-        self.send_notification("textDocument/didOpen", Some(params.clone()))
-            .await?;
-
-        // Mark document as open.
-        {
-            let mut open_docs = self.open_documents.lock().await;
-            open_docs.insert(uri.to_string());
-        }
-
-        // Send didSave to trigger cargo check.
+        // Drop the diagnostics stored so far, so that what gets reported next comes from the cargo
+        // check this didSave triggers rather than from before it.
+        self.diagnostics.lock().await.remove(uri);
         let save_params = json!({
             "textDocument": {
                 "uri": uri
@@ -348,8 +363,9 @@ impl RustAnalyzerClient {
         });
         self.send_notification("textDocument/didSave", Some(save_params))
             .await?;
+        self.saved_documents.insert(uri.to_string());
 
-        // Give rust-analyzer time to process the document and run cargo check.
+        // Give rust-analyzer time to get cargo check going.
         tokio::time::sleep(Duration::from_millis(DOCUMENT_OPEN_DELAY_MILLIS)).await;
 
         Ok(())
@@ -386,6 +402,7 @@ impl RustAnalyzerClient {
 
         // Clear open documents and diagnostics.
         self.open_documents.lock().await.clear();
+        self.saved_documents.clear();
         self.diagnostics.lock().await.clear();
         self.initialized = false;
     }
@@ -408,4 +425,84 @@ fn find_rust_analyzer() -> Result<PathBuf> {
             e
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    const URI: &str = "file:///tmp/lib.rs";
+
+    #[tokio::test]
+    async fn did_save_is_held_back_while_rust_analyzer_is_busy() {
+        let (mut client, mut child) = client_with_fake_stdin();
+
+        open(&mut client).await;
+        open(&mut client).await;
+
+        let sent = written(&mut client, &mut child).await;
+        assert_eq!(sent.matches("textDocument/didOpen").count(), 1, "{sent}");
+        assert_eq!(sent.matches("textDocument/didSave").count(), 0, "{sent}");
+    }
+
+    #[tokio::test]
+    async fn held_back_did_save_is_sent_once_rust_analyzer_is_quiescent() {
+        let (mut client, mut child) = client_with_fake_stdin();
+
+        open(&mut client).await;
+        client.quiescent.send_replace(true);
+        open(&mut client).await;
+        open(&mut client).await;
+
+        let sent = written(&mut client, &mut child).await;
+        assert_eq!(sent.matches("textDocument/didOpen").count(), 1, "{sent}");
+        assert_eq!(sent.matches("textDocument/didSave").count(), 1, "{sent}");
+    }
+
+    #[tokio::test]
+    async fn did_save_follows_did_open_while_rust_analyzer_is_quiescent() {
+        let (mut client, mut child) = client_with_fake_stdin();
+        client.quiescent.send_replace(true);
+
+        open(&mut client).await;
+        open(&mut client).await;
+
+        let sent = written(&mut client, &mut child).await;
+        assert_eq!(sent.matches("textDocument/didOpen").count(), 1, "{sent}");
+        assert_eq!(sent.matches("textDocument/didSave").count(), 1, "{sent}");
+    }
+
+    /// A client whose "rust-analyzer" is a `cat` process, so that everything the client writes
+    /// to its stdin can be read back from the child's stdout. Starts out non-quiescent, like a
+    /// freshly started rust-analyzer.
+    fn client_with_fake_stdin() -> (RustAnalyzerClient, Child) {
+        let mut child = Command::new("cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let mut client = RustAnalyzerClient::new(PathBuf::from("."));
+        client.stdin = Some(BufWriter::new(child.stdin.take().unwrap()));
+        (client, child)
+    }
+
+    async fn open(client: &mut RustAnalyzerClient) {
+        client.open_document(URI, "fn main() {}").await.unwrap();
+    }
+
+    /// Closes the client's stdin and returns everything it wrote.
+    async fn written(client: &mut RustAnalyzerClient, child: &mut Child) -> String {
+        client.stdin.take();
+        let mut output = String::new();
+        child
+            .stdout
+            .take()
+            .unwrap()
+            .read_to_string(&mut output)
+            .await
+            .unwrap();
+        child.wait().await.unwrap();
+        output
+    }
 }

--- a/src/lsp/connection.rs
+++ b/src/lsp/connection.rs
@@ -2,19 +2,22 @@ use log::{debug, error, info, warn};
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncReadExt, BufReader},
+    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, BufReader},
     sync::{oneshot, watch, Mutex},
+    task::JoinHandle,
 };
 
 use crate::protocol::lsp::LSPResponse;
 
+/// Spawns the tasks reading rust-analyzer's stdout and stderr, returning the stdout reader's
+/// handle: it finishes once rust-analyzer's stdout closes, i.e. once rust-analyzer is gone.
 pub fn start_handlers(
-    stdout: tokio::process::ChildStdout,
-    stderr: tokio::process::ChildStderr,
+    stdout: impl AsyncRead + Unpin + Send + 'static,
+    stderr: impl AsyncRead + Unpin + Send + 'static,
     pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
     quiescent: watch::Sender<bool>,
-) {
+) -> JoinHandle<()> {
     // Log stderr in background.
     tokio::spawn(handle_stderr(stderr));
 
@@ -24,10 +27,10 @@ pub fn start_handlers(
         pending_requests,
         diagnostics,
         quiescent,
-    ));
+    ))
 }
 
-async fn handle_stderr(stderr: tokio::process::ChildStderr) {
+async fn handle_stderr(stderr: impl AsyncRead + Unpin + Send + 'static) {
     let mut reader = BufReader::new(stderr);
     let mut buffer = String::new();
 
@@ -55,7 +58,7 @@ async fn handle_stderr(stderr: tokio::process::ChildStderr) {
 }
 
 async fn handle_stdout(
-    stdout: tokio::process::ChildStdout,
+    stdout: impl AsyncRead + Unpin + Send + 'static,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
     quiescent: watch::Sender<bool>,
@@ -101,6 +104,10 @@ async fn handle_stdout(
 
         handle_lsp_message(&json_buffer, &pending, &diagnostics, &quiescent).await;
     }
+
+    // rust-analyzer is gone, so no pending request will ever be answered: fail them now rather
+    // than letting each run into the request timeout.
+    pending.lock().await.clear();
 }
 
 fn parse_content_length(header: &str) -> Option<usize> {
@@ -249,6 +256,26 @@ mod tests {
         )
         .await;
         assert_eq!(diagnostics.lock().await["file:///a.rs"].len(), 1);
+    }
+
+    #[tokio::test]
+    async fn closed_stdout_fails_pending_requests() {
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let (sender, response) = oneshot::channel();
+        pending.lock().await.insert(1, sender);
+        let (quiescent, _status) = watch::channel(false);
+
+        // An already-closed stdout stands in for a rust-analyzer that died mid-request.
+        handle_stdout(
+            tokio::io::empty(),
+            Arc::clone(&pending),
+            Arc::new(Mutex::new(HashMap::new())),
+            quiescent,
+        )
+        .await;
+
+        assert!(response.await.is_err());
+        assert!(pending.lock().await.is_empty());
     }
 
     /// Feed one notification through `handle_notification` and return the diagnostics store.

--- a/src/lsp/connection.rs
+++ b/src/lsp/connection.rs
@@ -1,9 +1,9 @@
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
 use tokio::{
     io::{AsyncBufReadExt, AsyncReadExt, BufReader},
-    sync::{oneshot, Mutex},
+    sync::{oneshot, watch, Mutex},
 };
 
 use crate::protocol::lsp::LSPResponse;
@@ -13,12 +13,18 @@ pub fn start_handlers(
     stderr: tokio::process::ChildStderr,
     pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
+    quiescent: watch::Sender<bool>,
 ) {
     // Log stderr in background.
     tokio::spawn(handle_stderr(stderr));
 
     // Start response handler task.
-    tokio::spawn(handle_stdout(stdout, pending_requests, diagnostics));
+    tokio::spawn(handle_stdout(
+        stdout,
+        pending_requests,
+        diagnostics,
+        quiescent,
+    ));
 }
 
 async fn handle_stderr(stderr: tokio::process::ChildStderr) {
@@ -52,6 +58,7 @@ async fn handle_stdout(
     stdout: tokio::process::ChildStdout,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
+    quiescent: watch::Sender<bool>,
 ) {
     let mut reader = BufReader::new(stdout);
     let mut buffer = String::new();
@@ -92,7 +99,7 @@ async fn handle_stdout(
         let response_str = String::from_utf8_lossy(&json_buffer);
         debug!("Received LSP message: {}", response_str);
 
-        handle_lsp_message(&json_buffer, &pending, &diagnostics).await;
+        handle_lsp_message(&json_buffer, &pending, &diagnostics, &quiescent).await;
     }
 }
 
@@ -106,6 +113,7 @@ async fn handle_lsp_message(
     json_buffer: &[u8],
     pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: &Arc<Mutex<HashMap<String, Vec<Value>>>>,
+    quiescent: &watch::Sender<bool>,
 ) {
     let Ok(json_value) = serde_json::from_slice::<Value>(json_buffer) else {
         error!(
@@ -117,7 +125,7 @@ async fn handle_lsp_message(
 
     // Check if it's a notification (has method but no id).
     if json_value.get("method").is_some() && json_value.get("id").is_none() {
-        handle_notification(json_value, diagnostics).await;
+        handle_notification(json_value, diagnostics, quiescent).await;
         return;
     }
 
@@ -148,6 +156,7 @@ async fn handle_lsp_message(
 async fn handle_notification(
     json_value: Value,
     diagnostics: &Arc<Mutex<HashMap<String, Vec<Value>>>>,
+    quiescent: &watch::Sender<bool>,
 ) {
     let Some(method) = json_value.get("method").and_then(|m| m.as_str()) else {
         return;
@@ -155,23 +164,102 @@ async fn handle_notification(
 
     debug!("Received notification: {}", method);
 
-    if method != "textDocument/publishDiagnostics" {
-        return;
-    }
-
     let Some(params) = json_value.get("params") else {
         return;
     };
 
-    let Some(uri) = params.get("uri").and_then(|u| u.as_str()) else {
-        return;
-    };
+    match method {
+        "textDocument/publishDiagnostics" => {
+            let Some(uri) = params.get("uri").and_then(|u| u.as_str()) else {
+                return;
+            };
 
-    let Some(diags) = params.get("diagnostics").and_then(|d| d.as_array()) else {
-        return;
-    };
+            let Some(diags) = params.get("diagnostics").and_then(|d| d.as_array()) else {
+                return;
+            };
 
-    let mut diag_lock = diagnostics.lock().await;
-    diag_lock.insert(uri.to_string(), diags.clone());
-    info!("Stored {} diagnostics for {}", diags.len(), uri);
+            let mut diag_lock = diagnostics.lock().await;
+            diag_lock.insert(uri.to_string(), diags.clone());
+            info!("Stored {} diagnostics for {}", diags.len(), uri);
+        }
+        // rust-analyzer's status report, opted into through the `serverStatusNotification`
+        // client capability. `quiescent` is false while it has background work in flight, such
+        // as loading the workspace.
+        "experimental/serverStatus" => {
+            let Some(is_quiescent) = params.get("quiescent").and_then(|q| q.as_bool()) else {
+                return;
+            };
+
+            info!("rust-analyzer reports quiescent: {}", is_quiescent);
+            // Only a degraded status comes with a message, so it is always worth surfacing.
+            if let Some(message) = params.get("message").and_then(|m| m.as_str()) {
+                warn!("rust-analyzer status: {}", message);
+            }
+            quiescent.send_replace(is_quiescent);
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn server_status_tracks_quiescence() {
+        let (quiescent, status) = watch::channel(false);
+
+        notify(
+            "experimental/serverStatus",
+            json!({ "health": "ok", "quiescent": true }),
+            &quiescent,
+        )
+        .await;
+        assert!(*status.borrow());
+
+        notify(
+            "experimental/serverStatus",
+            json!({ "health": "warning", "quiescent": false, "message": "Loading" }),
+            &quiescent,
+        )
+        .await;
+        assert!(!*status.borrow());
+    }
+
+    #[tokio::test]
+    async fn server_status_without_quiescent_flag_is_ignored() {
+        let (quiescent, status) = watch::channel(true);
+        notify(
+            "experimental/serverStatus",
+            json!({ "health": "ok" }),
+            &quiescent,
+        )
+        .await;
+        assert!(*status.borrow());
+    }
+
+    #[tokio::test]
+    async fn publish_diagnostics_are_stored() {
+        let (quiescent, _status) = watch::channel(false);
+        let diagnostics = notify(
+            "textDocument/publishDiagnostics",
+            json!({ "uri": "file:///a.rs", "diagnostics": [{ "message": "boom" }] }),
+            &quiescent,
+        )
+        .await;
+        assert_eq!(diagnostics.lock().await["file:///a.rs"].len(), 1);
+    }
+
+    /// Feed one notification through `handle_notification` and return the diagnostics store.
+    async fn notify(
+        method: &str,
+        params: Value,
+        quiescent: &watch::Sender<bool>,
+    ) -> Arc<Mutex<HashMap<String, Vec<Value>>>> {
+        let diagnostics = Arc::new(Mutex::new(HashMap::new()));
+        let notification = json!({ "jsonrpc": "2.0", "method": method, "params": params });
+        handle_notification(notification, &diagnostics, quiescent).await;
+        diagnostics
+    }
 }

--- a/src/lsp/connection.rs
+++ b/src/lsp/connection.rs
@@ -39,9 +39,11 @@ async fn handle_stderr(stderr: tokio::process::ChildStderr) {
             break; // EOF
         }
 
+        // rust-analyzer is quiet on stderr by default, so what does show up there (its panic
+        // messages above all) is worth keeping at the default log level.
         let trimmed = buffer.trim();
         if !trimmed.is_empty() {
-            debug!("rust-analyzer stderr: {}", trimmed);
+            info!("rust-analyzer stderr: {}", trimmed);
         }
     }
 }

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -111,6 +111,8 @@ impl RustAnalyzerClient {
             .await
         {
             Ok(response) => Ok(response),
+            // A dead rust-analyzer must not pass for a clean workspace.
+            Err(e) if self.is_gone() => Err(e),
             Err(_) => {
                 // Fallback: return diagnostics for all open documents.
                 let mut all_diagnostics = json!({});

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use serde_json::json;
 use std::path::PathBuf;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
@@ -48,6 +48,19 @@ impl RustAnalyzerMCPServer {
     }
 
     pub(super) async fn ensure_client_started(&mut self) -> Result<()> {
+        // rust-analyzer does die on occasion (it panics on some requests, see open_document());
+        // keeping a dead client around would fail every tool call for the rest of this server's
+        // life, so respawn it instead.
+        if let Some(client) = &mut self.client {
+            if client.is_gone() {
+                match client.exit_status() {
+                    Some(status) => warn!("rust-analyzer exited ({status}), restarting it"),
+                    None => warn!("rust-analyzer closed its connection, restarting it"),
+                }
+                self.client = None;
+            }
+        }
+
         if self.client.is_none() {
             let mut client = RustAnalyzerClient::new(self.workspace_root.clone());
             client.start().await?;

--- a/test-support/src/ipc/client.rs
+++ b/test-support/src/ipc/client.rs
@@ -15,6 +15,9 @@ use super::server::socket_path;
 /// Maximum attempts for a tool call whose previous attempts failed on a transient timeout.
 const TOOL_CALL_ATTEMPTS: u32 = 3;
 
+/// Size past which a daemon's log file is rotated before launching another daemon.
+const MAX_DAEMON_LOG_BYTES: u64 = 8 * 1024 * 1024;
+
 /// Client that connects to the IPC MCP server
 pub struct IpcClient {
     stream: UnixStream,
@@ -112,8 +115,12 @@ impl IpcClient {
 
         // Start the server in background, keeping its stderr in a log file next to the socket
         // for post-mortem debugging. Append so racing daemon generations don't truncate each
-        // other's logs.
+        // other's logs, but rotate once the file has grown large: the MCP server's own logs land
+        // in it too, and nothing else ever trims it.
         let log_path = sock_path.with_extension("log");
+        if std::fs::metadata(&log_path).is_ok_and(|meta| meta.len() > MAX_DAEMON_LOG_BYTES) {
+            std::fs::rename(&log_path, log_path.with_extension("log.old"))?;
+        }
         let log_file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)

--- a/test-support/src/ipc/server.rs
+++ b/test-support/src/ipc/server.rs
@@ -68,22 +68,12 @@ pub fn start_server(workspace_path: &Path, project_type: &str) -> Result<()> {
         .env("XDG_CACHE_HOME", isolation_dir.join("cache"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        // Keep the MCP server's logs in this daemon's log file for post-mortem debugging.
+        .stderr(Stdio::inherit())
         .spawn()?;
 
     let mut stdin = rust_analyzer.stdin.take().unwrap();
     let mut stdout = BufReader::new(rust_analyzer.stdout.take().unwrap());
-    let stderr = rust_analyzer.stderr.take().unwrap();
-
-    // Consume stderr in background
-    thread::spawn(move || {
-        let stderr_reader = BufReader::new(stderr);
-        for line in stderr_reader.lines() {
-            if line.is_err() {
-                break;
-            }
-        }
-    });
 
     // Initialize rust-analyzer
     let request = json!({


### PR DESCRIPTION
Fixes the CI failure on main for the 0.3.0 release (run [32472367064](https://github.com/zeenix/rust-analyzer-mcp/actions/runs/32472367064)).

## What happened

All four `integration::diagnostics::*` tests failed with

```
Error: MCP error -1: Broken pipe (os error 32)
```

That error is `rust-analyzer-mcp` failing to write to rust-analyzer's stdin: rust-analyzer had died
inside the shared `test-project-diagnostics` daemon, and since the server never noticed, every later
tool call failed the same way. The run was the first on the Rust 1.98.0 toolchain (released
2026-08-20); the earlier red runs had been the unrelated "Request timeout" flake fixed in #24.

## Root cause

Reproduced locally with the 1.98.0 rust-analyzer, and — once the daemon kept the MCP server's
stderr — rust-analyzer's own panic showed up:

```
thread 'LspServer' panicked at crates/base-db/src/lib.rs:180:21:
Unable to get `FileSourceRootInput` with `vfs::FileId` (FileId(6), path: <unknown>); this is a bug
  <base_db::Files>::file_source_root → <ide::Analysis>::source_root_id → GlobalState::on_notification
notification: textDocument/didSave
```

`open_document()` sends `textDocument/didSave` right after `didOpen`. While rust-analyzer is still
loading the workspace it only applies VFS changes to its database between loads, so a freshly opened
document has no source root yet; its `didSave` handler then panics on the main thread (notification
handlers are not panic-isolated, unlike requests) and the process exits. Confirmed from the 1.98
sources: `process_changes()` is gated on `vfs_done`, the `quiescent` flag of
`experimental/serverStatus` implies `vfs_done`, and a workspace-wide `cargo check` is kicked off on
becoming quiescent. rust-analyzer 1.97.1 panics the same way — CI had just been winning the race,
and the toolchain update shifted the timing. Closest upstream report:
rust-lang/rust-analyzer#19406 (same assertion, different trigger).

## Fix

- `🚑️ lsp:` opt into rust-analyzer's `experimental/serverStatus` notifications, track its
  `quiescent` flag, and hold `didSave` back while it is busy — it is sent on the document's next
  use instead, and rust-analyzer's own post-load `cargo check` covers the gap in the meantime.
- `🥅 lsp:` recover when rust-analyzer dies: in-flight requests fail as soon as its stdout closes
  instead of running into the 30 s timeout, the next tool call respawns it (liveness keyed on the
  reader task), a `start()` failing halfway cannot orphan the child (`kill_on_drop`), and a
  workspace diagnostics request on a dead rust-analyzer no longer falls back to an empty,
  clean-looking report. Verified by hand: `SIGKILL` rust-analyzer under a live server → the next
  call logs `rust-analyzer exited (signal: 9 (SIGKILL)), restarting it` and succeeds.
- `🔊 test-support:` / `🔊 lsp:` keep the MCP server's stderr in the daemon log (rotated past
  8 MiB) and relay rust-analyzer's stderr at `info`, so the next such death explains itself;
  `👷 ci:` uploads the daemon logs as an artifact of failed runs.
- Unit tests for all of it, driving the client against `cat`/duplex streams instead of a real
  rust-analyzer; TDD: the "no didSave while busy" test reproduced the old behaviour before the fix.

Verified locally with the CI invocation (`cargo test --locked --workspace --release
--all-features`) on rust-analyzer 1.98.0 — 61 tests pass across the workspace, no rust-analyzer
panics in the daemon logs — and the integration suite on 1.97.1 with fresh daemons; fmt and clippy
gates clean.

Generated by Claude Fable 5 (claude-fable-5).
