### PR TITLE
🔖 Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.1](https://github.com/zeenix/rust-analyzer-mcp/compare/v0.3.0...v0.3.1) - 2026-08-21
+
+### Other
+
+- 🔧 Configure release-plz to use the repository's tag names
+- 👷 ci: Upload the test daemons' logs when the tests fail
+- 🥅 lsp: Recover from rust-analyzer exiting
+- 🚑️ lsp: Only send didSave once rust-analyzer is quiescent
+- 🔊 lsp: Log rust-analyzer's stderr at info level
+
+## [0.3.0](https://github.com/zeenix/rust-analyzer-mcp/compare/v0.2.0...v0.3.0) - 2026-08-21
+
+### Other
+
+- 👷 ci: Run the whole workspace's tests
+- 🧵 lsp: Register response channel before sending the request
+- ✅ Enable the shared IPC client tests
+- 🧑‍💻 Handle --help, --version and bad arguments
+- 🐛 Report the real crate version in initialize
+- 🩹 Cover more shutdown events, document run()'s hazards
+- 🐛 Fix server never exiting on SIGINT/SIGTERM
+- ♻️  Refactor
+- 🤖 Add gimoji info to CLAUDE.md
+- 🚀 Add GitHub release workflow for annotated tags
+- 🔧 CI: Use --locked option for cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "rust-analyzer-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["test-project", "test-project-diagnostics"]
 
 [package]
 name = "rust-analyzer-mcp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "MCP server for rust-analyzer integration"
 authors = ["Zeeshan Ali Khan <zeenix@gmail.com>"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+# Match the repository's existing `v<version>` tags, which the release workflow triggers on.
+git_tag_name = "v{{ version }}"

--- a/test-support/Cargo.toml
+++ b/test-support/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-support"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [[bin]]
 name = "test-support-server"


### PR DESCRIPTION
Release PR for 0.3.1, prepared with `release-plz set-version` + `release-plz update`. The version
had to be set explicitly: 0.3.0 is tagged and has a GitHub release, but was never published to
crates.io (latest there is 0.2.0), so release-plz considered 0.3.0 the still-pending release and
would not bump on its own.

- `test-support` is now `publish = false`, so `release-plz release` will not try to publish the
  test harness to crates.io (without it, release-plz planned a `test-support 0.1.0` release).
- `release-plz.toml` sets `git_tag_name = "v{{ version }}"` to match the existing `v0.x.y` tags and
  the release workflow's trigger; release-plz's default for this two-package workspace is
  `rust-analyzer-mcp-v…`, which also made the changelog link to non-existent tags.
- `CHANGELOG.md` is release-plz's output, split by hand into the 0.3.0 (tagged, unpublished) and
  0.3.1 entries.

After merging, `release-plz release` publishes 0.3.1 and tags `v0.3.1`. Note that release-plz also
creates a GitHub release by default (`git_release_enable`), while the existing tag-to-release
workflow will try to create one for the same tag; set `git_release_enable = false` in
`release-plz.toml` if the workflow should remain the one doing that.

Generated by Claude Fable 5 (claude-fable-5).
