### PR TITLE
🐛 Never answer JSON-RPC notifications, and answer pings

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -149,6 +149,15 @@ impl RustAnalyzerMCPServer {
                 continue;
             };
 
+            // A message without an `id` is a JSON-RPC notification, which must never be answered,
+            // not even with an error: a client that receives a response it did not ask for treats
+            // it as a protocol violation and closes the transport. `notifications/initialized` is
+            // part of every MCP handshake, so this used to break every spec-compliant client.
+            if request.id.is_none() {
+                debug!("Ignoring notification: {}", request.method);
+                continue;
+            }
+
             debug!("Received request: {}", request.method);
             // A shutdown signal must not wait for the request to finish: a tool call that
             // cold-starts rust-analyzer can run for minutes.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -251,6 +251,13 @@ impl RustAnalyzerMCPServer {
                     }
                 }),
             },
+            // A liveness check the client may send at any point, including before `initialize`.
+            // Its result is empty; what matters is that it comes back at all.
+            "ping" => MCPResponse::Success {
+                jsonrpc: "2.0".to_string(),
+                id: request.id,
+                result: json!({}),
+            },
             "tools/list" => MCPResponse::Success {
                 jsonrpc: "2.0".to_string(),
                 id: request.id,

--- a/tests/integration/notifications.rs
+++ b/tests/integration/notifications.rs
@@ -44,6 +44,30 @@ async fn notifications_are_not_answered() -> Result<()> {
 }
 
 #[tokio::test]
+async fn ping_is_answered() -> Result<()> {
+    // The client's liveness check, which it may send before `initialize` and at any point after.
+    let responses = talk_to_server(&[r#"{"jsonrpc":"2.0","id":3,"method":"ping"}"#]).await?;
+
+    assert_eq!(responses.len(), 1, "got: {responses:?}");
+    assert_eq!(responses[0]["id"], 3);
+    assert_eq!(responses[0]["result"], serde_json::json!({}));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_null_id_is_not_a_request() -> Result<()> {
+    // `id: null` is a request in JSON-RPC but malformed in MCP, where the id "MUST NOT be null".
+    // Answering it would mean sending a response with an id no client can match up.
+    let responses =
+        talk_to_server(&[r#"{"jsonrpc":"2.0","id":null,"method":"tools/list"}"#]).await?;
+
+    assert!(responses.is_empty(), "got: {responses:?}");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn unknown_requests_still_get_an_error() -> Result<()> {
     let responses =
         talk_to_server(&[r#"{"jsonrpc":"2.0","id":7,"method":"no/such/method"}"#]).await?;

--- a/tests/integration/notifications.rs
+++ b/tests/integration/notifications.rs
@@ -1,0 +1,118 @@
+//! Tests for the JSON-RPC framing of the MCP layer itself.
+//!
+//! These drive the server binary directly instead of going through the shared test daemon: what
+//! matters here is the exact set of lines the server writes, which the daemon's request/response
+//! pairing hides.
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::{path::PathBuf, process::Stdio, time::Duration};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    process::Command,
+};
+
+/// How long the server gets to answer; none of these requests starts rust-analyzer.
+const TIMEOUT: Duration = Duration::from_secs(30);
+
+#[tokio::test]
+async fn notifications_are_not_answered() -> Result<()> {
+    // The `notifications/initialized` of the MCP handshake, and a notification the server knows
+    // nothing about: neither may draw a response, not even a "method not found" error.
+    let responses = talk_to_server(&[
+        r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+        r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":0}}"#,
+        r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+    ])
+    .await?;
+
+    let ids: Vec<&Value> = responses.iter().map(|response| &response["id"]).collect();
+    assert_eq!(
+        ids,
+        vec![&Value::from(0), &Value::from(1)],
+        "only the two requests may be answered, got: {responses:?}"
+    );
+    for response in &responses {
+        assert!(
+            response.get("error").is_none(),
+            "unexpected error response: {response}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn unknown_requests_still_get_an_error() -> Result<()> {
+    let responses =
+        talk_to_server(&[r#"{"jsonrpc":"2.0","id":7,"method":"no/such/method"}"#]).await?;
+
+    assert_eq!(responses.len(), 1, "got: {responses:?}");
+    assert_eq!(responses[0]["id"], 7);
+    assert_eq!(responses[0]["error"]["code"], -32601);
+
+    Ok(())
+}
+
+/// Feeds `messages` to a fresh server, one per line, and returns everything it wrote back.
+///
+/// Closing stdin afterwards makes the server exit, so reading its stdout to EOF is enough to see
+/// every response it had to give — including the ones it should not have written.
+async fn talk_to_server(messages: &[&str]) -> Result<Vec<Value>> {
+    let mut server = Command::new(server_binary()?)
+        .arg(workspace())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let mut stdin = server.stdin.take().expect("stdin was piped");
+    for message in messages {
+        stdin.write_all(message.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+    }
+    stdin.flush().await?;
+    drop(stdin);
+
+    let mut stdout = server.stdout.take().expect("stdout was piped");
+    let mut output = String::new();
+    tokio::time::timeout(TIMEOUT, stdout.read_to_string(&mut output))
+        .await
+        .map_err(|_| anyhow!("the server did not exit within {TIMEOUT:?}"))??;
+
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).map_err(|e| anyhow!("{e}, in: {line}")))
+        .collect()
+}
+
+/// The workspace the server is pointed at; no test here gets as far as analysing it.
+fn workspace() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-project")
+}
+
+fn server_binary() -> Result<PathBuf> {
+    let target = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target");
+    let release = target.join("release/rust-analyzer-mcp");
+    let debug = target.join("debug/rust-analyzer-mcp");
+
+    // Prefer whichever matches the profile the tests themselves were built with.
+    let (first, second) = if cfg!(debug_assertions) {
+        (debug, release)
+    } else {
+        (release, debug)
+    };
+    if first.exists() {
+        return Ok(first);
+    }
+    if second.exists() {
+        return Ok(second);
+    }
+    Err(anyhow!(
+        "no rust-analyzer-mcp binary in {}; run `cargo build` first",
+        target.display()
+    ))
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,7 @@
 mod integration {
     mod diagnostics;
     mod mcp_server_test;
+    mod notifications;
     mod shared_test;
     mod shutdown;
 }


### PR DESCRIPTION
Fixes #21.

`notifications/initialized` is part of every MCP handshake and, like any JSON-RPC notification, carries no `id`. `handle_request()` routed it through the method router anyway, so the server answered it with:

```json
{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found: notifications/initialized","data":null}}
```

A client that follows the specification treats a response it never asked for as a protocol violation and closes the transport; the server then sees the broken pipe and shuts down, which is why it looked like it exited right after initialization.

## What changed

- **`src/mcp/server.rs`**: id-less messages are dropped before they reach the method router — unconditionally and method-agnostically, since an unknown *notification* gets no reply either way. Requests (which do carry an `id`) still get their `-32601`.
- **Second commit**: `ping` is answered with an empty result. It's a request every client may send at any time, including before `initialize`, to check the server is alive; it fell through to the catch-all and came back as "Method not found", which a client is free to read as a dead server. Say the word and I'll drop the commit if you'd rather keep this PR to the notification bug.

## Tests

`tests/integration/notifications.rs` drives the server binary directly — the shared test daemon pairs each request with one response, which is exactly what would hide a stray extra line. It feeds messages down stdin, closes it, and asserts on the exact set of lines that came back:

- `initialize` + `notifications/initialized` + `notifications/cancelled` + `tools/list` → exactly two responses, ids `0` and `1`.
- an unknown *request* still gets `-32601`, so the silencing cannot grow too broad.
- `ping` → `{}`.
- `{"id":null,...}` → nothing at all. MCP says the id "MUST NOT be null", so the message is malformed; answering it would mean sending back an id no client can match up. Today that falls out of `Option<Value>` mapping both spellings to `None` — the test pins the behaviour rather than leaving it incidental.

None of these start rust-analyzer, so they run in milliseconds. Verified the first one fails on `main` and passes here.

## Noticed but not touched

- `MCPResponse::Success` still has an optional `id` at the type level, so a future path could reintroduce an id-less response. Making it non-optional would rule that out by construction — a refactor, happy to do it separately.
- Tool failures come back as JSON-RPC errors with code `-1`; the tools spec would have execution failures come back as a result with `isError: true` so the model sees the message. Separate issue.