### PR TITLE
🐛 Tell rust-analyzer's requests apart from its answers

### DIFF
--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -10,7 +10,7 @@ use std::{
     time::Duration,
 };
 use tokio::{
-    io::{AsyncWriteExt, BufWriter},
+    io::BufWriter,
     process::{Child, Command},
     sync::{oneshot, watch, Mutex},
     task::JoinHandle,
@@ -24,11 +24,13 @@ use crate::{
     uri,
 };
 
+use super::connection::{send_message, Outgoing};
+
 pub struct RustAnalyzerClient {
     pub(super) process: Option<Child>,
     pub(super) request_id: Arc<Mutex<u64>>,
     pub(super) workspace_root: PathBuf,
-    pub(super) stdin: Option<BufWriter<tokio::process::ChildStdin>>,
+    pub(super) stdin: Option<Outgoing<tokio::process::ChildStdin>>,
     pub(super) pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     pub(super) initialized: bool,
     /// What rust-analyzer was last told about each open document, keyed by normalized URI.
@@ -111,10 +113,13 @@ impl RustAnalyzerClient {
             .take()
             .ok_or_else(|| anyhow!("Failed to get stderr"))?;
 
-        self.stdin = Some(BufWriter::new(stdin));
+        let stdin = Arc::new(Mutex::new(BufWriter::new(stdin)));
+        self.stdin = Some(Arc::clone(&stdin));
 
         // Start connection handlers, with a pending-request map of their own: the reader of an
-        // earlier process fails whatever is left in its map when it finishes.
+        // earlier process fails whatever is left in its map when it finishes. It writes to
+        // rust-analyzer as well as reading from it, since rust-analyzer's own requests are its
+        // to answer.
         self.pending_requests = Arc::new(Mutex::new(HashMap::new()));
         self.reader = Some(super::connection::start_handlers(
             stdout,
@@ -122,6 +127,8 @@ impl RustAnalyzerClient {
             Arc::clone(&self.pending_requests),
             Arc::clone(&self.diagnostics),
             self.quiescent.clone(),
+            stdin,
+            settings(),
         ));
 
         self.process = Some(child);
@@ -130,18 +137,9 @@ impl RustAnalyzerClient {
         self.initialize().await?;
         self.initialized = true;
 
-        // Send workspace/didChangeConfiguration to ensure settings are applied.
-        let config_params = json!({
-            "settings": {
-                "rust-analyzer": {
-                    "checkOnSave": {
-                        "enable": true,
-                        "command": "check",
-                        "allTargets": true
-                    }
-                }
-            }
-        });
+        // Tell rust-analyzer its configuration changed. It ignores what comes with the
+        // notification and asks for the settings itself, which the reader task answers.
+        let config_params = json!({ "settings": { "rust-analyzer": settings() } });
         let _ = self
             .send_notification("workspace/didChangeConfiguration", Some(config_params))
             .await;
@@ -161,18 +159,13 @@ impl RustAnalyzerClient {
             "params": params.unwrap_or(json!({}))
         });
 
-        let content = serde_json::to_string(&notification)?;
-        let message = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
-
         info!("Sending LSP notification: {}", method);
 
-        let Some(stdin) = &mut self.stdin else {
+        let Some(stdin) = &self.stdin else {
             return Err(anyhow!("No stdin available"));
         };
 
-        stdin.write_all(message.as_bytes()).await?;
-        stdin.flush().await?;
-        Ok(())
+        send_message(stdin, &notification).await
     }
 
     pub(super) async fn send_request(
@@ -192,8 +185,7 @@ impl RustAnalyzerClient {
             params: params.clone(),
         };
 
-        let content = serde_json::to_string(&request)?;
-        let message = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
+        let request = serde_json::to_value(request)?;
 
         info!("Sending LSP request: {} with params: {:?}", method, params);
 
@@ -204,18 +196,14 @@ impl RustAnalyzerClient {
         let pending_requests = self.pending_requests.clone();
         pending_requests.lock().await.insert(id, tx);
 
-        let Some(stdin) = &mut self.stdin else {
+        let Some(stdin) = &self.stdin else {
             pending_requests.lock().await.remove(&id);
             return Err(anyhow!("No stdin available"));
         };
 
-        let mut written = stdin.write_all(message.as_bytes()).await;
-        if written.is_ok() {
-            written = stdin.flush().await;
-        }
-        if let Err(e) = written {
+        if let Err(e) = send_message(stdin, &request).await {
             pending_requests.lock().await.remove(&id);
-            return Err(e.into());
+            return Err(e);
         }
 
         // Wait for response with timeout. The channel only closes unanswered when the reader
@@ -234,27 +222,7 @@ impl RustAnalyzerClient {
         let init_params = json!({
             "processId": std::process::id(),
             "rootUri": uri::path_to_uri(&self.workspace_root)?,
-            "initializationOptions": {
-                "cargo": {
-                    "buildScripts": {
-                        "enable": true
-                    }
-                },
-                "checkOnSave": {
-                    "enable": true,
-                    "command": "check",
-                    "allTargets": true
-                },
-                "diagnostics": {
-                    "enable": true,
-                    "experimental": {
-                        "enable": true
-                    }
-                },
-                "procMacro": {
-                    "enable": true
-                }
-            },
+            "initializationOptions": settings(),
             "capabilities": {
                 "textDocument": {
                     "hover": {
@@ -473,6 +441,34 @@ impl RustAnalyzerClient {
     }
 }
 
+/// The configuration rust-analyzer is asked to run with.
+///
+/// Sent once as `initializationOptions`, and handed back whenever rust-analyzer asks for its
+/// configuration -- which it does, rather than reading the notification that told it to.
+fn settings() -> Value {
+    json!({
+        "cargo": {
+            "buildScripts": {
+                "enable": true
+            }
+        },
+        "checkOnSave": {
+            "enable": true,
+            "command": "check",
+            "allTargets": true
+        },
+        "diagnostics": {
+            "enable": true,
+            "experimental": {
+                "enable": true
+            }
+        },
+        "procMacro": {
+            "enable": true
+        }
+    })
+}
+
 /// What rust-analyzer was last told about a document, so that the next thing it is told about
 /// it can follow on.
 pub(super) struct OpenDocument {
@@ -675,6 +671,8 @@ mod tests {
             Arc::clone(&client.pending_requests),
             Arc::clone(&client.diagnostics),
             client.quiescent.clone(),
+            Arc::new(Mutex::new(BufWriter::new(tokio::io::sink()))),
+            settings(),
         ));
         tokio::task::yield_now().await;
         assert!(!client.is_gone());
@@ -709,7 +707,9 @@ mod tests {
             .spawn()
             .unwrap();
         let mut client = RustAnalyzerClient::new(PathBuf::from("."));
-        client.stdin = Some(BufWriter::new(child.stdin.take().unwrap()));
+        client.stdin = Some(Arc::new(Mutex::new(BufWriter::new(
+            child.stdin.take().unwrap(),
+        ))));
         (client, child)
     }
 

--- a/src/lsp/connection.rs
+++ b/src/lsp/connection.rs
@@ -1,22 +1,48 @@
+use anyhow::Result;
 use log::{debug, error, info, warn};
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::{collections::HashMap, sync::Arc};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, BufReader},
+    io::{
+        AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter,
+    },
     sync::{oneshot, watch, Mutex},
     task::JoinHandle,
 };
 
 use crate::{protocol::lsp::LSPResponse, uri};
 
+/// The writing half of the connection to rust-analyzer.
+///
+/// Shared, because rust-analyzer's own requests are answered by the task reading its stdout
+/// while whoever drives the client is writing requests of its own.
+pub type Outgoing<W> = Arc<Mutex<BufWriter<W>>>;
+
+/// Writes one LSP message, header and all.
+pub async fn send_message<W: AsyncWrite + Unpin>(
+    outgoing: &Outgoing<W>,
+    message: &Value,
+) -> Result<()> {
+    let content = serde_json::to_string(message)?;
+    let framed = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
+
+    let mut writer = outgoing.lock().await;
+    writer.write_all(framed.as_bytes()).await?;
+    writer.flush().await?;
+
+    Ok(())
+}
+
 /// Spawns the tasks reading rust-analyzer's stdout and stderr, returning the stdout reader's
 /// handle: it finishes once rust-analyzer's stdout closes, i.e. once rust-analyzer is gone.
-pub fn start_handlers(
+pub fn start_handlers<W: AsyncWrite + Unpin + Send + 'static>(
     stdout: impl AsyncRead + Unpin + Send + 'static,
     stderr: impl AsyncRead + Unpin + Send + 'static,
     pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
     quiescent: watch::Sender<bool>,
+    outgoing: Outgoing<W>,
+    settings: Value,
 ) -> JoinHandle<()> {
     // Log stderr in background.
     tokio::spawn(handle_stderr(stderr));
@@ -27,6 +53,8 @@ pub fn start_handlers(
         pending_requests,
         diagnostics,
         quiescent,
+        outgoing,
+        settings,
     ))
 }
 
@@ -57,11 +85,13 @@ async fn handle_stderr(stderr: impl AsyncRead + Unpin + Send + 'static) {
     }
 }
 
-async fn handle_stdout(
+async fn handle_stdout<W: AsyncWrite + Unpin>(
     stdout: impl AsyncRead + Unpin + Send + 'static,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
     quiescent: watch::Sender<bool>,
+    outgoing: Outgoing<W>,
+    settings: Value,
 ) {
     let mut reader = BufReader::new(stdout);
     let mut buffer = String::new();
@@ -102,7 +132,15 @@ async fn handle_stdout(
         let response_str = String::from_utf8_lossy(&json_buffer);
         debug!("Received LSP message: {}", response_str);
 
-        handle_lsp_message(&json_buffer, &pending, &diagnostics, &quiescent).await;
+        handle_lsp_message(
+            &json_buffer,
+            &pending,
+            &diagnostics,
+            &quiescent,
+            &outgoing,
+            &settings,
+        )
+        .await;
     }
 
     // rust-analyzer is gone, so no pending request will ever be answered: fail them now rather
@@ -116,11 +154,13 @@ fn parse_content_length(header: &str) -> Option<usize> {
         .and_then(|s| s.trim().parse().ok())
 }
 
-async fn handle_lsp_message(
+async fn handle_lsp_message<W: AsyncWrite + Unpin>(
     json_buffer: &[u8],
     pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     diagnostics: &Arc<Mutex<HashMap<String, Vec<Value>>>>,
     quiescent: &watch::Sender<bool>,
+    outgoing: &Outgoing<W>,
+    settings: &Value,
 ) {
     let Ok(json_value) = serde_json::from_slice::<Value>(json_buffer) else {
         error!(
@@ -130,13 +170,26 @@ async fn handle_lsp_message(
         return;
     };
 
-    // Check if it's a notification (has method but no id).
-    if json_value.get("method").is_some() && json_value.get("id").is_none() {
-        handle_notification(json_value, diagnostics, quiescent).await;
-        return;
+    // What a message is turns entirely on whether it names a method and whether it carries an
+    // id. Anything that names a method is rust-analyzer talking to us rather than answering us,
+    // and taking one of those for an answer means handing whoever is waiting on that id a reply
+    // to a question they never asked -- rust-analyzer numbers its own requests from zero, in the
+    // same space as ours.
+    match (json_value.get("method"), json_value.get("id")) {
+        (Some(method), Some(id)) => {
+            let method = method.as_str().unwrap_or_default().to_string();
+            answer_request(&method, id.clone(), &json_value, outgoing, settings).await;
+        }
+        (Some(_), None) => handle_notification(json_value, diagnostics, quiescent).await,
+        (None, Some(_)) => handle_response(json_value, pending).await,
+        (None, None) => debug!("Ignoring LSP message that is neither request nor response"),
     }
+}
 
-    // Try to handle as response.
+async fn handle_response(
+    json_value: Value,
+    pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
+) {
     let Ok(response) = serde_json::from_value::<LSPResponse>(json_value) else {
         return;
     };
@@ -152,11 +205,68 @@ async fn handle_lsp_message(
 
     if let Some(error) = response.error {
         error!("LSP error for request {}: {}", id, error);
-        let _ = sender.send(serde_json::json!(null));
+        let _ = sender.send(json!(null));
     } else {
-        let result = response.result.unwrap_or(serde_json::json!(null));
+        let result = response.result.unwrap_or(json!(null));
         info!("Sending result for request {}: {:?}", id, result);
         let _ = sender.send(result);
+    }
+}
+
+/// Answers a request rust-analyzer made of us.
+///
+/// Every one of them has to be answered exactly once, with the id it came with: rust-analyzer
+/// keeps them in a queue it expects to empty, and panics outright on an answer to something it
+/// never asked.
+async fn answer_request<W: AsyncWrite + Unpin>(
+    method: &str,
+    id: Value,
+    request: &Value,
+    outgoing: &Outgoing<W>,
+    settings: &Value,
+) {
+    debug!("Received request from rust-analyzer: {}", method);
+
+    let response = match method {
+        // Asked after every `didChangeConfiguration`, and what comes back replaces the
+        // configuration rust-analyzer started with -- so this answers with all of it, once per
+        // section asked about.
+        "workspace/configuration" => {
+            let sections = request
+                .pointer("/params/items")
+                .and_then(Value::as_array)
+                .map_or(1, Vec::len);
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": vec![settings.clone(); sections],
+            })
+        }
+        // A progress report is about to start under a token of rust-analyzer's choosing. There
+        // is nothing to set up on this side; the answer is the whole point.
+        "window/workDoneProgress/create" => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": null,
+        }),
+        _ => {
+            info!(
+                "Declining unsupported request from rust-analyzer: {}",
+                method
+            );
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": -32601,
+                    "message": format!("Method not found: {method}"),
+                },
+            })
+        }
+    };
+
+    if let Err(e) = send_message(outgoing, &response).await {
+        error!("Failed to answer rust-analyzer's {} request: {}", method, e);
     }
 }
 
@@ -272,11 +382,152 @@ mod tests {
             Arc::clone(&pending),
             Arc::new(Mutex::new(HashMap::new())),
             quiescent,
+            Arc::new(Mutex::new(BufWriter::new(tokio::io::sink()))),
+            json!({}),
         )
         .await;
 
         assert!(response.await.is_err());
         assert!(pending.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_request_from_rust_analyzer_is_not_taken_for_an_answer() {
+        // rust-analyzer numbers its own requests from zero, in the same space as ours, so one of
+        // these landing on a pending id would answer a question nobody asked with nothing.
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let (sender, response) = oneshot::channel();
+        pending.lock().await.insert(3, sender);
+        let (outgoing, mut rust_analyzer) = outgoing();
+
+        deliver(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "window/workDoneProgress/create",
+                "params": { "token": "rust-analyzer/flycheck/0" }
+            }),
+            &pending,
+            &outgoing,
+            &json!({}),
+        )
+        .await;
+
+        assert!(pending.lock().await.contains_key(&3));
+        let mut response = response;
+        assert!(response.try_recv().is_err(), "nothing may have been sent");
+        let answer = framed(&mut rust_analyzer).await;
+        assert_eq!(answer["id"], 3);
+        assert_eq!(answer["result"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn configuration_requests_are_answered_with_the_settings_we_asked_for() {
+        // What comes back replaces the configuration rust-analyzer was started with, so a bare
+        // "no configuration here" would quietly undo the initialization options.
+        let settings = json!({ "checkOnSave": { "enable": true } });
+        let (outgoing, mut rust_analyzer) = outgoing();
+
+        deliver(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "workspace/configuration",
+                "params": { "items": [
+                    { "section": "rust-analyzer" },
+                    { "section": "rust-analyzer", "scopeUri": "file:///ws" }
+                ] }
+            }),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &outgoing,
+            &settings,
+        )
+        .await;
+
+        let answer = framed(&mut rust_analyzer).await;
+        assert_eq!(answer["id"], 0);
+        assert_eq!(answer["result"], json!([settings, settings]));
+    }
+
+    #[tokio::test]
+    async fn requests_we_cannot_serve_are_declined_rather_than_dropped() {
+        // Left unanswered they pile up in rust-analyzer's queue of requests it is still waiting
+        // on, and it is not the client's place to decide when one no longer matters.
+        let (outgoing, mut rust_analyzer) = outgoing();
+
+        deliver(
+            json!({ "jsonrpc": "2.0", "id": 7, "method": "client/registerCapability" }),
+            &Arc::new(Mutex::new(HashMap::new())),
+            &outgoing,
+            &json!({}),
+        )
+        .await;
+
+        let answer = framed(&mut rust_analyzer).await;
+        assert_eq!(answer["id"], 7);
+        assert_eq!(answer["error"]["code"], -32601);
+    }
+
+    #[tokio::test]
+    async fn answers_still_reach_whoever_is_waiting() {
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let (sender, response) = oneshot::channel();
+        pending.lock().await.insert(1, sender);
+        let (outgoing, _rust_analyzer) = outgoing();
+
+        deliver(
+            json!({ "jsonrpc": "2.0", "id": 1, "result": { "contents": "docs" } }),
+            &pending,
+            &outgoing,
+            &json!({}),
+        )
+        .await;
+
+        assert_eq!(response.await.unwrap(), json!({ "contents": "docs" }));
+        assert!(pending.lock().await.is_empty());
+    }
+
+    /// Feed one message through the classifier.
+    async fn deliver(
+        message: Value,
+        pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
+        outgoing: &Outgoing<tokio::io::DuplexStream>,
+        settings: &Value,
+    ) {
+        let (quiescent, _status) = watch::channel(false);
+        handle_lsp_message(
+            message.to_string().as_bytes(),
+            pending,
+            &Arc::new(Mutex::new(HashMap::new())),
+            &quiescent,
+            outgoing,
+            settings,
+        )
+        .await;
+    }
+
+    /// An outgoing half of a connection, along with the end rust-analyzer would read from.
+    fn outgoing() -> (Outgoing<tokio::io::DuplexStream>, tokio::io::DuplexStream) {
+        let (ours, theirs) = tokio::io::duplex(4096);
+        (Arc::new(Mutex::new(BufWriter::new(ours))), theirs)
+    }
+
+    /// The next message written to the connection, unwrapped from its header.
+    async fn framed(rust_analyzer: &mut tokio::io::DuplexStream) -> Value {
+        let mut buffer = vec![0u8; 4096];
+        let read = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            rust_analyzer.read(&mut buffer),
+        )
+        .await
+        .expect("a message must be written")
+        .unwrap();
+
+        let message = String::from_utf8_lossy(&buffer[..read]).to_string();
+        let (header, body) = message.split_once("\r\n\r\n").expect("{message}");
+        assert!(header.starts_with("Content-Length: "), "{header}");
+
+        serde_json::from_str(body).unwrap()
     }
 
     /// Feed one notification through `handle_notification` and return the diagnostics store.


### PR DESCRIPTION
Groundwork for part two of #12. **Stacked on #30** (which is stacked on #29).

## Why

`handle_lsp_message()` treated everything that wasn't a notification as an answer to something we asked:

```rust
if json_value.get("method").is_some() && json_value.get("id").is_none() { … notification … }
let Ok(response) = serde_json::from_value::<LSPResponse>(json_value) else { return };
```

`LSPResponse` has no `deny_unknown_fields`, so a *request* from rust-analyzer (`{jsonrpc, id, method, params}`) parses as a response with `result: None` — and the code then does `pending.remove(&id)` and hands whoever is waiting on that id a `null`. The tool call behind it reports an empty result it never received.

rust-analyzer numbers its outgoing requests from 0 in the same space ours are numbered in (ours start at 1 and climb). It stays theoretical today only because rust-analyzer asks us exactly one thing — `workspace/configuration`, id 0. Part two of #12 declares `window.workDoneProgress`, which turns that into a `window/workDoneProgress/create` per progress run, and the collision stops being theoretical. Hence its own PR: it is a latent correctness bug either way.

## What changed

- **`src/lsp/connection.rs`**: messages are sorted by what they carry — method + id is a request, method alone a notification, id alone an answer — and requests are answered:
  - `workspace/configuration` → the settings the server was started with, once per section asked about. This is what makes the `workspace/didChangeConfiguration` we send at startup mean anything: rust-analyzer ignores what that notification carries and asks for the settings itself, so until now our configuration was dropped on the floor. (Answering with nothing would be worse than not answering: what comes back *replaces* the config rust-analyzer initialized with.)
  - `window/workDoneProgress/create` → `null`. Nothing to set up on our side; the answer is the point.
  - anything else → `-32601`, rather than being left unanswered, since rust-analyzer holds the request open otherwise. Never with a wrong or unsolicited id: `complete_request` panics its main loop on one of those.
- Answering means the reader task writes to rust-analyzer as well as reading from it, so the writing half is now an `Arc<Mutex<BufWriter<_>>>` shared with it, and the `Content-Length` framing both sides need moved next to it as `send_message()`.
- The settings themselves moved into one `settings()` used by `initializationOptions` and by the configuration answer, so the two cannot drift.

## Tests

Four new unit tests in `src/lsp/connection.rs`, driving the classifier over a duplex stream:

- a `window/workDoneProgress/create` with id 3 leaves a pending request with id 3 untouched and writes an answer with id 3 (this is the bug);
- `workspace/configuration` with two items is answered with two copies of the settings;
- an unsupported request is declined with `-32601` rather than dropped;
- an actual answer still reaches its waiter and clears the pending entry.

`cargo test --workspace` and `cargo clippy -- -D warnings` are green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkyeTcMaEJKvoU58pYSN8Q)_