### PR TITLE
🐛 Report diagnostics from a check of the file as it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ Get diagnostics (errors, warnings, hints) for a specific file.
 **Parameters:**
 - `file_path`: Path to the Rust file
 
+Runs a fresh `cargo check` and waits for it to finish, so the result describes the file as it is on
+disk rather than as it was when first looked at. If the check does not finish in time, the result
+says so in a `note` field and asking again picks up the rest.
+
 Returns diagnostics with severity levels (error, warning, hint, information), messages, and location
 ranges. Includes a summary count of diagnostics by severity.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,3 +6,23 @@ pub const GRACEFUL_SHUTDOWN_TIMEOUT_SECS: u64 = 5;
 
 /// Delay after opening a document to allow rust-analyzer to process it.
 pub const DOCUMENT_OPEN_DELAY_MILLIS: u64 = 200;
+
+/// How long to wait for a cargo check to start after asking rust-analyzer for one.
+///
+/// Long enough to cover a check already running being cancelled to make way for the one asked
+/// for, which means waiting for a cargo process to go away.
+pub const FLYCHECK_START_TIMEOUT_SECS: u64 = 2;
+
+/// How many times to ask for a cargo check that never starts.
+///
+/// rust-analyzer works out which checks to restart on a task it abandons whenever its analysis
+/// is superseded -- by the very change being asked about, among other things -- so a request can
+/// go nowhere through no fault of its own. Asking again is all it takes.
+pub const FLYCHECK_REQUEST_ATTEMPTS: usize = 5;
+
+/// How long to wait for a cargo check that has started to finish.
+pub const FLYCHECK_TIMEOUT_SECS: u64 = 30;
+
+/// How long to wait for rust-analyzer to finish loading a workspace before asking it something
+/// whose answer depends on the whole of it, in seconds.
+pub const WORKSPACE_LOAD_TIMEOUT_SECS: u64 = 30;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -24,7 +24,7 @@ use crate::{
     uri,
 };
 
-use super::connection::{send_message, Outgoing};
+use super::connection::{send_message, Connection, Diagnostics, Flycheck, Outgoing};
 
 pub struct RustAnalyzerClient {
     pub(super) process: Option<Child>,
@@ -35,10 +35,17 @@ pub struct RustAnalyzerClient {
     pub(super) initialized: bool,
     /// What rust-analyzer was last told about each open document, keyed by normalized URI.
     pub(super) open_documents: Arc<Mutex<HashMap<String, OpenDocument>>>,
-    pub(super) diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
+    pub(super) diagnostics: Diagnostics,
     /// Whether rust-analyzer last reported itself quiescent, i.e. with no background work such
     /// as loading the workspace in flight. Fed by its `experimental/serverStatus` notifications.
     pub(super) quiescent: watch::Sender<bool>,
+    /// The cargo checks rust-analyzer has run, fed by its `$/progress` notifications.
+    pub(super) flycheck: watch::Sender<Flycheck>,
+    /// Whether waiting for a cargo check has already been given up on once. Ones older than
+    /// the reports never report a check, and waiting on a report that is not coming would cost
+    /// every diagnostics call the whole timeout -- but this only holds while no check has been
+    /// reported at all, so one that turns up later puts the waiting back.
+    pub(super) gave_up_on_checks: bool,
     /// Open documents whose `didSave` has been sent, see [`Self::open_document`].
     pub(super) saved_documents: HashSet<String>,
     /// The task reading rust-analyzer's stdout; it finishing means rust-analyzer is gone.
@@ -59,6 +66,8 @@ impl RustAnalyzerClient {
             open_documents: Arc::new(Mutex::new(HashMap::new())),
             diagnostics: Arc::new(Mutex::new(HashMap::new())),
             quiescent: watch::channel(false).0,
+            flycheck: watch::channel(Flycheck::default()).0,
+            gave_up_on_checks: false,
             saved_documents: HashSet::new(),
             reader: None,
         }
@@ -124,11 +133,14 @@ impl RustAnalyzerClient {
         self.reader = Some(super::connection::start_handlers(
             stdout,
             stderr,
-            Arc::clone(&self.pending_requests),
-            Arc::clone(&self.diagnostics),
-            self.quiescent.clone(),
-            stdin,
-            settings(),
+            Connection {
+                pending_requests: Arc::clone(&self.pending_requests),
+                diagnostics: Arc::clone(&self.diagnostics),
+                quiescent: self.quiescent.clone(),
+                flycheck: self.flycheck.clone(),
+                outgoing: stdin,
+                settings: settings(),
+            },
         ));
 
         self.process = Some(child);
@@ -268,6 +280,11 @@ impl RustAnalyzerClient {
                     "didChangeConfiguration": {
                         "dynamicRegistration": false
                     }
+                },
+                // Opt into the progress reports rust-analyzer gives on its background work,
+                // the cargo checks above all. It stays silent about all of it otherwise.
+                "window": {
+                    "workDoneProgress": true
                 },
                 // Opt into `experimental/serverStatus` notifications, which report whether
                 // rust-analyzer is quiescent.
@@ -427,6 +444,8 @@ impl RustAnalyzerClient {
         self.open_documents.lock().await.clear();
         self.saved_documents.clear();
         self.diagnostics.lock().await.clear();
+        self.flycheck.send_replace(Flycheck::default());
+        self.gave_up_on_checks = false;
         self.initialized = false;
     }
 
@@ -520,6 +539,10 @@ mod tests {
 
     #[cfg(unix)]
     const URI: &str = "file:///tmp/lib.rs";
+
+    /// The progress token rust-analyzer reports a workspace's cargo checks under.
+    #[cfg(unix)]
+    const FLYCHECK: &str = "rust-analyzer/flycheck/0";
 
     #[cfg(unix)]
     #[tokio::test]
@@ -639,6 +662,98 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn diagnostics_are_asked_for_and_waited_on() {
+        let (mut client, mut child) = client_with_fake_stdin();
+        client.quiescent.send_replace(true);
+
+        // Stand in for rust-analyzer: report a check starting and finishing, with something to
+        // say about the file, once the client is waiting for one.
+        let flycheck = client.flycheck.clone();
+        let diagnostics = Arc::clone(&client.diagnostics);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            flycheck.send_modify(|flycheck| flycheck.begin(FLYCHECK));
+            diagnostics.lock().await.insert(
+                URI.to_string(),
+                vec![json!({ "message": "mismatched types" })],
+            );
+            flycheck.send_modify(|flycheck| flycheck.end(FLYCHECK));
+        });
+
+        let fresh = client.fresh_diagnostics(URI).await.unwrap();
+
+        assert!(fresh.complete);
+        assert_eq!(fresh.items[0]["message"], "mismatched types");
+        let sent = written(&mut client, &mut child).await;
+        assert!(sent.contains("rust-analyzer/runFlycheck"), "{sent}");
+        // And rust-analyzer's own analysis is asked for rather than waited for.
+        assert!(sent.contains("textDocument/diagnostic"), "{sent}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn diagnostics_come_back_marked_when_no_check_runs() {
+        // What an older rust-analyzer, or one with checking switched off, leaves us with: no
+        // check to wait for, so what is already known is the best there is.
+        let (mut client, _child) = client_with_fake_stdin();
+        client.quiescent.send_replace(true);
+
+        let fresh = client.fresh_diagnostics(URI).await.unwrap();
+
+        assert!(!fresh.complete);
+        assert_eq!(fresh.items, json!([]));
+        // And having learnt that, it does not wait the same wait out again.
+        assert!(client.gave_up_on_checks);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn a_check_reported_late_puts_the_waiting_back() {
+        // Giving up on a rust-analyzer that reports no checks must not outlast a check turning
+        // up: on a workspace big enough, the first one begins after the wait has been given up.
+        let (mut client, _child) = client_with_fake_stdin();
+        client.quiescent.send_replace(true);
+        client.fresh_diagnostics(URI).await.unwrap();
+        assert!(client.gave_up_on_checks);
+
+        client.flycheck.send_modify(|flycheck| {
+            flycheck.begin(FLYCHECK);
+            flycheck.end(FLYCHECK);
+        });
+
+        // So this call waits again, and the check it asks for is waited out.
+        let flycheck = client.flycheck.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            flycheck.send_modify(|flycheck| flycheck.begin(FLYCHECK));
+            flycheck.send_modify(|flycheck| flycheck.end(FLYCHECK));
+        });
+
+        let fresh = client.fresh_diagnostics(URI).await.unwrap();
+
+        assert!(fresh.complete);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn diagnostics_from_a_workspace_still_loading_are_marked() {
+        // A file rust-analyzer has not reached yet looks exactly like a file with nothing wrong
+        // with it, so an unqualified "no errors" here would be a lie.
+        let (mut client, _child) = client_with_fake_stdin();
+        let flycheck = client.flycheck.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            flycheck.send_modify(|flycheck| flycheck.begin(FLYCHECK));
+            flycheck.send_modify(|flycheck| flycheck.end(FLYCHECK));
+        });
+
+        let fresh = client.fresh_diagnostics(URI).await.unwrap();
+
+        assert!(!fresh.complete);
+    }
+
+    #[cfg(unix)]
     #[tokio::test]
     async fn exit_status_reflects_whether_rust_analyzer_is_alive() {
         let mut client = RustAnalyzerClient::new(PathBuf::from("."));
@@ -668,11 +783,14 @@ mod tests {
         client.reader = Some(super::super::connection::start_handlers(
             stdout,
             tokio::io::empty(),
-            Arc::clone(&client.pending_requests),
-            Arc::clone(&client.diagnostics),
-            client.quiescent.clone(),
-            Arc::new(Mutex::new(BufWriter::new(tokio::io::sink()))),
-            settings(),
+            Connection {
+                pending_requests: Arc::clone(&client.pending_requests),
+                diagnostics: Arc::clone(&client.diagnostics),
+                quiescent: client.quiescent.clone(),
+                flycheck: client.flycheck.clone(),
+                outgoing: Arc::new(Mutex::new(BufWriter::new(tokio::io::sink()))),
+                settings: settings(),
+            },
         ));
         tokio::task::yield_now().await;
         assert!(!client.is_gone());

--- a/src/lsp/connection.rs
+++ b/src/lsp/connection.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use log::{debug, error, info, warn};
 use serde_json::{json, Value};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use tokio::{
     io::{
         AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter,
@@ -11,6 +14,56 @@ use tokio::{
 };
 
 use crate::{protocol::lsp::LSPResponse, uri};
+
+/// What rust-analyzer has published about each document, by normalized URI.
+pub type Diagnostics = Arc<Mutex<HashMap<String, Vec<Value>>>>;
+
+/// The cargo checks rust-analyzer has run, as reported by its progress notifications.
+///
+/// A check is the only thing that produces the diagnostics rustc gives, so knowing whether one
+/// has run since a file changed is the difference between reporting on the code as it is and
+/// reporting on the code as it was.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Flycheck {
+    /// The checks in flight, by the progress token each reports under. There can be several:
+    /// rust-analyzer runs one per workspace.
+    running: HashSet<String>,
+    /// How many checks have begun, counted so that a check started after some point in time can
+    /// be told from one that was already running.
+    started: u64,
+}
+
+impl Flycheck {
+    /// Records a check beginning under `token`.
+    pub fn begin(&mut self, token: &str) {
+        self.running.insert(token.to_string());
+        self.started += 1;
+    }
+
+    /// Records the check under `token` ending, whether it ran out or was cancelled to make way
+    /// for another.
+    pub fn end(&mut self, token: &str) {
+        self.running.remove(token);
+    }
+
+    /// Whether a check begun since `earlier` has run to completion, with none still going.
+    pub fn caught_up_with(&self, earlier: &Self) -> bool {
+        self.started > earlier.started && self.running.is_empty()
+    }
+
+    /// Whether a check has begun since `earlier`.
+    pub fn started_since(&self, earlier: &Self) -> bool {
+        self.started > earlier.started
+    }
+
+    /// Whether rust-analyzer has yet to report a single check.
+    pub fn never_ran_one(&self) -> bool {
+        self.started == 0
+    }
+}
+
+/// The progress token prefix rust-analyzer reports its cargo checks under.
+const FLYCHECK_TOKEN: &str = "rust-analyzer/flycheck/";
 
 /// The writing half of the connection to rust-analyzer.
 ///
@@ -33,29 +86,35 @@ pub async fn send_message<W: AsyncWrite + Unpin>(
     Ok(())
 }
 
+/// What the tasks reading rust-analyzer's output work on: everything they hand a message to,
+/// and everything they answer one with.
+pub struct Connection<W> {
+    /// The requests waiting for an answer, by the id each was sent under.
+    pub pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
+    /// The last diagnostics published for each document.
+    pub diagnostics: Diagnostics,
+    /// Whether rust-analyzer has any background work in flight.
+    pub quiescent: watch::Sender<bool>,
+    /// The cargo checks rust-analyzer has run.
+    pub flycheck: watch::Sender<Flycheck>,
+    /// The writing half, for answering rust-analyzer's own requests.
+    pub outgoing: Outgoing<W>,
+    /// The settings to answer rust-analyzer's configuration requests with.
+    pub settings: Value,
+}
+
 /// Spawns the tasks reading rust-analyzer's stdout and stderr, returning the stdout reader's
 /// handle: it finishes once rust-analyzer's stdout closes, i.e. once rust-analyzer is gone.
 pub fn start_handlers<W: AsyncWrite + Unpin + Send + 'static>(
     stdout: impl AsyncRead + Unpin + Send + 'static,
     stderr: impl AsyncRead + Unpin + Send + 'static,
-    pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
-    diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
-    quiescent: watch::Sender<bool>,
-    outgoing: Outgoing<W>,
-    settings: Value,
+    connection: Connection<W>,
 ) -> JoinHandle<()> {
     // Log stderr in background.
     tokio::spawn(handle_stderr(stderr));
 
     // Start response handler task.
-    tokio::spawn(handle_stdout(
-        stdout,
-        pending_requests,
-        diagnostics,
-        quiescent,
-        outgoing,
-        settings,
-    ))
+    tokio::spawn(handle_stdout(stdout, connection))
 }
 
 async fn handle_stderr(stderr: impl AsyncRead + Unpin + Send + 'static) {
@@ -87,11 +146,7 @@ async fn handle_stderr(stderr: impl AsyncRead + Unpin + Send + 'static) {
 
 async fn handle_stdout<W: AsyncWrite + Unpin>(
     stdout: impl AsyncRead + Unpin + Send + 'static,
-    pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
-    diagnostics: Arc<Mutex<HashMap<String, Vec<Value>>>>,
-    quiescent: watch::Sender<bool>,
-    outgoing: Outgoing<W>,
-    settings: Value,
+    connection: Connection<W>,
 ) {
     let mut reader = BufReader::new(stdout);
     let mut buffer = String::new();
@@ -132,20 +187,12 @@ async fn handle_stdout<W: AsyncWrite + Unpin>(
         let response_str = String::from_utf8_lossy(&json_buffer);
         debug!("Received LSP message: {}", response_str);
 
-        handle_lsp_message(
-            &json_buffer,
-            &pending,
-            &diagnostics,
-            &quiescent,
-            &outgoing,
-            &settings,
-        )
-        .await;
+        handle_lsp_message(&json_buffer, &connection).await;
     }
 
     // rust-analyzer is gone, so no pending request will ever be answered: fail them now rather
     // than letting each run into the request timeout.
-    pending.lock().await.clear();
+    connection.pending_requests.lock().await.clear();
 }
 
 fn parse_content_length(header: &str) -> Option<usize> {
@@ -154,14 +201,7 @@ fn parse_content_length(header: &str) -> Option<usize> {
         .and_then(|s| s.trim().parse().ok())
 }
 
-async fn handle_lsp_message<W: AsyncWrite + Unpin>(
-    json_buffer: &[u8],
-    pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
-    diagnostics: &Arc<Mutex<HashMap<String, Vec<Value>>>>,
-    quiescent: &watch::Sender<bool>,
-    outgoing: &Outgoing<W>,
-    settings: &Value,
-) {
+async fn handle_lsp_message<W: AsyncWrite + Unpin>(json_buffer: &[u8], connection: &Connection<W>) {
     let Ok(json_value) = serde_json::from_slice::<Value>(json_buffer) else {
         error!(
             "Failed to parse LSP message: {}",
@@ -178,10 +218,10 @@ async fn handle_lsp_message<W: AsyncWrite + Unpin>(
     match (json_value.get("method"), json_value.get("id")) {
         (Some(method), Some(id)) => {
             let method = method.as_str().unwrap_or_default().to_string();
-            answer_request(&method, id.clone(), &json_value, outgoing, settings).await;
+            answer_request(&method, id.clone(), &json_value, connection).await;
         }
-        (Some(_), None) => handle_notification(json_value, diagnostics, quiescent).await,
-        (None, Some(_)) => handle_response(json_value, pending).await,
+        (Some(_), None) => handle_notification(json_value, connection).await,
+        (None, Some(_)) => handle_response(json_value, &connection.pending_requests).await,
         (None, None) => debug!("Ignoring LSP message that is neither request nor response"),
     }
 }
@@ -222,8 +262,7 @@ async fn answer_request<W: AsyncWrite + Unpin>(
     method: &str,
     id: Value,
     request: &Value,
-    outgoing: &Outgoing<W>,
-    settings: &Value,
+    connection: &Connection<W>,
 ) {
     debug!("Received request from rust-analyzer: {}", method);
 
@@ -239,7 +278,7 @@ async fn answer_request<W: AsyncWrite + Unpin>(
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
-                "result": vec![settings.clone(); sections],
+                "result": vec![connection.settings.clone(); sections],
             })
         }
         // A progress report is about to start under a token of rust-analyzer's choosing. There
@@ -265,16 +304,12 @@ async fn answer_request<W: AsyncWrite + Unpin>(
         }
     };
 
-    if let Err(e) = send_message(outgoing, &response).await {
+    if let Err(e) = send_message(&connection.outgoing, &response).await {
         error!("Failed to answer rust-analyzer's {} request: {}", method, e);
     }
 }
 
-async fn handle_notification(
-    json_value: Value,
-    diagnostics: &Arc<Mutex<HashMap<String, Vec<Value>>>>,
-    quiescent: &watch::Sender<bool>,
-) {
+async fn handle_notification<W: AsyncWrite + Unpin>(json_value: Value, connection: &Connection<W>) {
     let Some(method) = json_value.get("method").and_then(|m| m.as_str()) else {
         return;
     };
@@ -295,7 +330,7 @@ async fn handle_notification(
                 return;
             };
 
-            let mut diag_lock = diagnostics.lock().await;
+            let mut diag_lock = connection.diagnostics.lock().await;
             // Keyed the same way the lookups spell it, see `uri::normalize()`.
             diag_lock.insert(uri::normalize(uri), diags.clone());
             info!("Stored {} diagnostics for {}", diags.len(), uri);
@@ -313,25 +348,54 @@ async fn handle_notification(
             if let Some(message) = params.get("message").and_then(|m| m.as_str()) {
                 warn!("rust-analyzer status: {}", message);
             }
-            quiescent.send_replace(is_quiescent);
+            connection.quiescent.send_replace(is_quiescent);
+        }
+        // Progress on whatever rust-analyzer has running. The only ones worth following are the
+        // cargo checks, whose token names the workspace being checked.
+        "$/progress" => {
+            let Some(token) = params.get("token").and_then(|t| t.as_str()) else {
+                return;
+            };
+            if !token.starts_with(FLYCHECK_TOKEN) {
+                return;
+            }
+
+            match params.pointer("/value/kind").and_then(|k| k.as_str()) {
+                Some("begin") => {
+                    info!("cargo check started: {}", token);
+                    connection
+                        .flycheck
+                        .send_modify(|flycheck| flycheck.begin(token));
+                }
+                // Sent when a check finishes and when one is cancelled, which is what a restart
+                // does to the check it replaces.
+                Some("end") => {
+                    info!("cargo check finished: {}", token);
+                    connection
+                        .flycheck
+                        .send_modify(|flycheck| flycheck.end(token));
+                }
+                _ => {}
+            }
         }
         _ => {}
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+    use tokio::io::DuplexStream;
 
     #[tokio::test]
     async fn server_status_tracks_quiescence() {
-        let (quiescent, status) = watch::channel(false);
+        let (connection, _rust_analyzer) = connection();
+        let status = connection.quiescent.subscribe();
 
         notify(
             "experimental/serverStatus",
             json!({ "health": "ok", "quiescent": true }),
-            &quiescent,
+            &connection,
         )
         .await;
         assert!(*status.borrow());
@@ -339,7 +403,7 @@ mod tests {
         notify(
             "experimental/serverStatus",
             json!({ "health": "warning", "quiescent": false, "message": "Loading" }),
-            &quiescent,
+            &connection,
         )
         .await;
         assert!(!*status.borrow());
@@ -347,58 +411,108 @@ mod tests {
 
     #[tokio::test]
     async fn server_status_without_quiescent_flag_is_ignored() {
-        let (quiescent, status) = watch::channel(true);
+        let (connection, _rust_analyzer) = connection();
+        connection.quiescent.send_replace(true);
+        let status = connection.quiescent.subscribe();
+
         notify(
             "experimental/serverStatus",
             json!({ "health": "ok" }),
-            &quiescent,
+            &connection,
         )
         .await;
+
         assert!(*status.borrow());
     }
 
     #[tokio::test]
     async fn publish_diagnostics_are_stored() {
-        let (quiescent, _status) = watch::channel(false);
-        let diagnostics = notify(
+        let (connection, _rust_analyzer) = connection();
+
+        notify(
             "textDocument/publishDiagnostics",
             json!({ "uri": "file:///a.rs", "diagnostics": [{ "message": "boom" }] }),
-            &quiescent,
+            &connection,
         )
         .await;
-        assert_eq!(diagnostics.lock().await["file:///a.rs"].len(), 1);
+
+        assert_eq!(connection.diagnostics.lock().await["file:///a.rs"].len(), 1);
     }
 
     #[tokio::test]
     async fn closed_stdout_fails_pending_requests() {
-        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let (connection, _rust_analyzer) = connection();
         let (sender, response) = oneshot::channel();
+        let pending = Arc::clone(&connection.pending_requests);
         pending.lock().await.insert(1, sender);
-        let (quiescent, _status) = watch::channel(false);
 
         // An already-closed stdout stands in for a rust-analyzer that died mid-request.
-        handle_stdout(
-            tokio::io::empty(),
-            Arc::clone(&pending),
-            Arc::new(Mutex::new(HashMap::new())),
-            quiescent,
-            Arc::new(Mutex::new(BufWriter::new(tokio::io::sink()))),
-            json!({}),
-        )
-        .await;
+        handle_stdout(tokio::io::empty(), connection).await;
 
         assert!(response.await.is_err());
         assert!(pending.lock().await.is_empty());
     }
 
     #[tokio::test]
+    async fn cargo_checks_are_followed_from_start_to_finish() {
+        let (connection, _rust_analyzer) = connection();
+        let idle = connection.flycheck.borrow().clone();
+
+        progress("rust-analyzer/flycheck/0", "begin", &connection).await;
+        assert!(connection.flycheck.borrow().started_since(&idle));
+        assert!(!connection.flycheck.borrow().caught_up_with(&idle));
+
+        // rust-analyzer runs a check per workspace, and one of them finishing is not the end of
+        // the checking.
+        progress("rust-analyzer/flycheck/1", "begin", &connection).await;
+        progress("rust-analyzer/flycheck/0", "end", &connection).await;
+        assert!(!connection.flycheck.borrow().caught_up_with(&idle));
+
+        progress("rust-analyzer/flycheck/1", "end", &connection).await;
+        assert!(connection.flycheck.borrow().caught_up_with(&idle));
+    }
+
+    #[tokio::test]
+    async fn a_check_cancelled_for_a_restart_is_not_a_check_that_ran() {
+        // Asking for a check while one is running cancels it, and a cancelled check ends the
+        // same way a finished one does. What tells them apart is that the restart begins another.
+        let (connection, _rust_analyzer) = connection();
+        progress("rust-analyzer/flycheck/0", "begin", &connection).await;
+        let when_we_asked = connection.flycheck.borrow().clone();
+
+        progress("rust-analyzer/flycheck/0", "end", &connection).await;
+        assert!(!connection.flycheck.borrow().caught_up_with(&when_we_asked));
+
+        progress("rust-analyzer/flycheck/0", "begin", &connection).await;
+        assert!(!connection.flycheck.borrow().caught_up_with(&when_we_asked));
+
+        progress("rust-analyzer/flycheck/0", "end", &connection).await;
+        assert!(connection.flycheck.borrow().caught_up_with(&when_we_asked));
+    }
+
+    #[tokio::test]
+    async fn progress_on_anything_else_is_not_a_cargo_check() {
+        let (connection, _rust_analyzer) = connection();
+
+        for token in [
+            "rustAnalyzer/cachePriming",
+            "rustAnalyzer/Fetching",
+            "rustAnalyzer/Indexing",
+        ] {
+            progress(token, "begin", &connection).await;
+            progress(token, "end", &connection).await;
+        }
+
+        assert_eq!(*connection.flycheck.borrow(), Flycheck::default());
+    }
+
+    #[tokio::test]
     async fn a_request_from_rust_analyzer_is_not_taken_for_an_answer() {
         // rust-analyzer numbers its own requests from zero, in the same space as ours, so one of
         // these landing on a pending id would answer a question nobody asked with nothing.
-        let pending = Arc::new(Mutex::new(HashMap::new()));
-        let (sender, response) = oneshot::channel();
-        pending.lock().await.insert(3, sender);
-        let (outgoing, mut rust_analyzer) = outgoing();
+        let (connection, mut rust_analyzer) = connection();
+        let (sender, mut response) = oneshot::channel();
+        connection.pending_requests.lock().await.insert(3, sender);
 
         deliver(
             json!({
@@ -407,14 +521,11 @@ mod tests {
                 "method": "window/workDoneProgress/create",
                 "params": { "token": "rust-analyzer/flycheck/0" }
             }),
-            &pending,
-            &outgoing,
-            &json!({}),
+            &connection,
         )
         .await;
 
-        assert!(pending.lock().await.contains_key(&3));
-        let mut response = response;
+        assert!(connection.pending_requests.lock().await.contains_key(&3));
         assert!(response.try_recv().is_err(), "nothing may have been sent");
         let answer = framed(&mut rust_analyzer).await;
         assert_eq!(answer["id"], 3);
@@ -424,9 +535,10 @@ mod tests {
     #[tokio::test]
     async fn configuration_requests_are_answered_with_the_settings_we_asked_for() {
         // What comes back replaces the configuration rust-analyzer was started with, so a bare
-        // "no configuration here" would quietly undo the initialization options.
+        // "nothing here" would quietly undo the initialization options.
+        let (mut connection, mut rust_analyzer) = connection();
         let settings = json!({ "checkOnSave": { "enable": true } });
-        let (outgoing, mut rust_analyzer) = outgoing();
+        connection.settings = settings.clone();
 
         deliver(
             json!({
@@ -438,9 +550,7 @@ mod tests {
                     { "section": "rust-analyzer", "scopeUri": "file:///ws" }
                 ] }
             }),
-            &Arc::new(Mutex::new(HashMap::new())),
-            &outgoing,
-            &settings,
+            &connection,
         )
         .await;
 
@@ -451,15 +561,13 @@ mod tests {
 
     #[tokio::test]
     async fn requests_we_cannot_serve_are_declined_rather_than_dropped() {
-        // Left unanswered they pile up in rust-analyzer's queue of requests it is still waiting
-        // on, and it is not the client's place to decide when one no longer matters.
-        let (outgoing, mut rust_analyzer) = outgoing();
+        // Left unanswered they pile up in rust-analyzer's queue of requests it is waiting on,
+        // and it is not the client's place to decide when one no longer matters.
+        let (connection, mut rust_analyzer) = connection();
 
         deliver(
             json!({ "jsonrpc": "2.0", "id": 7, "method": "client/registerCapability" }),
-            &Arc::new(Mutex::new(HashMap::new())),
-            &outgoing,
-            &json!({}),
+            &connection,
         )
         .await;
 
@@ -470,50 +578,61 @@ mod tests {
 
     #[tokio::test]
     async fn answers_still_reach_whoever_is_waiting() {
-        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let (connection, _rust_analyzer) = connection();
         let (sender, response) = oneshot::channel();
-        pending.lock().await.insert(1, sender);
-        let (outgoing, _rust_analyzer) = outgoing();
+        connection.pending_requests.lock().await.insert(1, sender);
 
         deliver(
             json!({ "jsonrpc": "2.0", "id": 1, "result": { "contents": "docs" } }),
-            &pending,
-            &outgoing,
-            &json!({}),
+            &connection,
         )
         .await;
 
         assert_eq!(response.await.unwrap(), json!({ "contents": "docs" }));
-        assert!(pending.lock().await.is_empty());
+        assert!(connection.pending_requests.lock().await.is_empty());
+    }
+
+    /// A connection with nothing going on yet, along with the end rust-analyzer would read from.
+    fn connection() -> (Connection<DuplexStream>, DuplexStream) {
+        let (ours, theirs) = tokio::io::duplex(4096);
+        let connection = Connection {
+            pending_requests: Arc::new(Mutex::new(HashMap::new())),
+            diagnostics: Arc::new(Mutex::new(HashMap::new())),
+            quiescent: watch::channel(false).0,
+            flycheck: watch::channel(Flycheck::default()).0,
+            outgoing: Arc::new(Mutex::new(BufWriter::new(ours))),
+            settings: json!({}),
+        };
+
+        (connection, theirs)
     }
 
     /// Feed one message through the classifier.
-    async fn deliver(
-        message: Value,
-        pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
-        outgoing: &Outgoing<tokio::io::DuplexStream>,
-        settings: &Value,
-    ) {
-        let (quiescent, _status) = watch::channel(false);
-        handle_lsp_message(
-            message.to_string().as_bytes(),
-            pending,
-            &Arc::new(Mutex::new(HashMap::new())),
-            &quiescent,
-            outgoing,
-            settings,
+    async fn deliver(message: Value, connection: &Connection<DuplexStream>) {
+        handle_lsp_message(message.to_string().as_bytes(), connection).await;
+    }
+
+    /// Feed one notification through the classifier.
+    async fn notify(method: &str, params: Value, connection: &Connection<DuplexStream>) {
+        deliver(
+            json!({ "jsonrpc": "2.0", "method": method, "params": params }),
+            connection,
         )
         .await;
     }
 
-    /// An outgoing half of a connection, along with the end rust-analyzer would read from.
-    fn outgoing() -> (Outgoing<tokio::io::DuplexStream>, tokio::io::DuplexStream) {
-        let (ours, theirs) = tokio::io::duplex(4096);
-        (Arc::new(Mutex::new(BufWriter::new(ours))), theirs)
+    /// Feed one `$/progress` notification through the classifier.
+    async fn progress(token: &str, kind: &str, connection: &Connection<DuplexStream>) {
+        notify(
+            "$/progress",
+            json!({ "token": token, "value": { "kind": kind } }),
+            connection,
+        )
+        .await;
     }
 
     /// The next message written to the connection, unwrapped from its header.
-    async fn framed(rust_analyzer: &mut tokio::io::DuplexStream) -> Value {
+    async fn framed(rust_analyzer: &mut DuplexStream) -> Value {
         let mut buffer = vec![0u8; 4096];
         let read = tokio::time::timeout(
             std::time::Duration::from_secs(5),
@@ -528,17 +647,5 @@ mod tests {
         assert!(header.starts_with("Content-Length: "), "{header}");
 
         serde_json::from_str(body).unwrap()
-    }
-
-    /// Feed one notification through `handle_notification` and return the diagnostics store.
-    async fn notify(
-        method: &str,
-        params: Value,
-        quiescent: &watch::Sender<bool>,
-    ) -> Arc<Mutex<HashMap<String, Vec<Value>>>> {
-        let diagnostics = Arc::new(Mutex::new(HashMap::new()));
-        let notification = json!({ "jsonrpc": "2.0", "method": method, "params": params });
-        handle_notification(notification, &diagnostics, quiescent).await;
-        diagnostics
     }
 }

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -1,9 +1,50 @@
 use anyhow::Result;
-use log::info;
+use log::{info, warn};
 use serde_json::{json, Value};
+use std::time::Duration;
+use tokio::sync::watch;
 
-use super::client::RustAnalyzerClient;
-use crate::uri;
+use super::{client::RustAnalyzerClient, connection::Flycheck};
+use crate::{
+    config::{
+        DOCUMENT_OPEN_DELAY_MILLIS, FLYCHECK_REQUEST_ATTEMPTS, FLYCHECK_START_TIMEOUT_SECS,
+        FLYCHECK_TIMEOUT_SECS, WORKSPACE_LOAD_TIMEOUT_SECS,
+    },
+    uri,
+};
+
+/// What rust-analyzer marks the diagnostics it worked out itself with, as opposed to the ones it
+/// read out of a cargo check.
+const ANALYSIS_SOURCE: &str = "rust-analyzer";
+
+/// Diagnostics, and whether anything was still going on that could add to them.
+pub struct FreshDiagnostics {
+    pub items: Value,
+    /// False when the workspace was still loading, or the cargo check did not finish or never
+    /// started -- any of which makes these the best available rather than the last word.
+    pub complete: bool,
+}
+
+/// Waits for rust-analyzer's checks to reach `condition`, giving up after `timeout`.
+async fn wait_for(
+    progress: &mut watch::Receiver<Flycheck>,
+    timeout: Duration,
+    condition: impl Fn(&Flycheck) -> bool,
+) -> bool {
+    let wait = async {
+        loop {
+            if condition(&progress.borrow_and_update()) {
+                return true;
+            }
+            // Only fails once the client is gone, and then nothing is coming.
+            if progress.changed().await.is_err() {
+                return false;
+            }
+        }
+    };
+
+    tokio::time::timeout(timeout, wait).await.unwrap_or(false)
+}
 
 impl RustAnalyzerClient {
     pub async fn hover(&mut self, uri: &str, line: u32, character: u32) -> Result<Value> {
@@ -77,9 +118,9 @@ impl RustAnalyzerClient {
             "Available URIs with diagnostics: {:?}",
             diag_lock.keys().collect::<Vec<_>>()
         );
-        if let Some(diags) = diag_lock.get(&key) {
-            info!("Found {} stored diagnostics for {}", diags.len(), uri);
-            return Ok(json!(diags));
+        if let Some(diagnostics) = diag_lock.get(&key) {
+            info!("Found {} stored diagnostics for {}", diagnostics.len(), uri);
+            return Ok(json!(diagnostics));
         }
         drop(diag_lock);
 
@@ -99,6 +140,179 @@ impl RustAnalyzerClient {
         } else {
             Ok(json!([]))
         }
+    }
+
+    /// Diagnostics for `uri` from a cargo check that has seen the file as it is now.
+    ///
+    /// The diagnostics rustc gives -- the ones anyone actually wants -- only ever arrive as the
+    /// result of a check, and a check takes as long as it takes. Asking rust-analyzer for one and
+    /// waiting for it to finish is the only way to answer with the code in front of us rather
+    /// than whatever was last reported about it.
+    pub async fn fresh_diagnostics(&mut self, uri: &str) -> Result<FreshDiagnostics> {
+        // A report on a workspace rust-analyzer is still loading covers the part of it that has
+        // been reached, and a file it has not reached looks exactly like a file with nothing
+        // wrong with it.
+        let loaded = self
+            .wait_until_loaded(Duration::from_secs(WORKSPACE_LOAD_TIMEOUT_SECS))
+            .await;
+        if !loaded {
+            warn!("rust-analyzer is still loading the workspace; reporting on what it has");
+        }
+
+        let before = self.flycheck.borrow().clone();
+        let mut progress = self.flycheck.subscribe();
+
+        // A check covers the whole workspace and republishes everything it has to say about it,
+        // so everything said before it is superseded.
+        self.diagnostics.lock().await.clear();
+
+        let params = json!({ "textDocument": { "uri": uri } });
+        self.send_notification("rust-analyzer/runFlycheck", Some(params.clone()))
+            .await?;
+
+        // Waiting was given up on before, and nothing has reported a check since: a
+        // rust-analyzer too old to report them, or told not to check at all. One that turns up
+        // after all -- a workspace big enough for the first check to start late -- makes this
+        // false again, and the waiting resumes.
+        if self.gave_up_on_checks && before.never_ran_one() {
+            return Ok(FreshDiagnostics {
+                items: self.current_diagnostics(uri).await?,
+                complete: false,
+            });
+        }
+
+        // Waiting for the check to start is a step of its own, because it may never do: the
+        // request can be dropped along with the analysis it was working from, and rust-analyzer
+        // may be old enough not to know it or be configured not to check at all. Ask again a
+        // couple of times for the first case; the second gives up quickly rather than sitting
+        // out the whole timeout every call.
+        let mut started = false;
+        for attempt in 1..=FLYCHECK_REQUEST_ATTEMPTS {
+            started = wait_for(
+                &mut progress,
+                Duration::from_secs(FLYCHECK_START_TIMEOUT_SECS),
+                |flycheck| flycheck.started_since(&before),
+            )
+            .await;
+            if started || attempt == FLYCHECK_REQUEST_ATTEMPTS {
+                break;
+            }
+
+            info!("Asking for a cargo check of {} again", uri);
+            self.send_notification("rust-analyzer/runFlycheck", Some(params.clone()))
+                .await?;
+        }
+        if !started {
+            info!("No cargo check started for {}, reporting what we have", uri);
+            // Nothing has ever reported a check here, so take it that nothing will and stop
+            // making every later call wait the same wait out. Only until one does: the check
+            // this call asked for may yet begin, and the next call will see that it did.
+            if self.flycheck.borrow().never_ran_one() {
+                warn!("rust-analyzer has yet to report a cargo check; not waiting for one");
+                self.gave_up_on_checks = true;
+            }
+
+            return Ok(FreshDiagnostics {
+                items: self.current_diagnostics(uri).await?,
+                complete: false,
+            });
+        }
+
+        let finished = wait_for(
+            &mut progress,
+            Duration::from_secs(FLYCHECK_TIMEOUT_SECS),
+            |flycheck| flycheck.caught_up_with(&before),
+        )
+        .await;
+        if !finished {
+            warn!("cargo check for {} is still running, reporting early", uri);
+        }
+
+        // The results are published just after the check reports itself done, from a turn of
+        // rust-analyzer's loop we cannot see the end of.
+        tokio::time::sleep(Duration::from_millis(DOCUMENT_OPEN_DELAY_MILLIS)).await;
+
+        Ok(FreshDiagnostics {
+            items: self.current_diagnostics(uri).await?,
+            complete: loaded && finished,
+        })
+    }
+
+    /// Waits until rust-analyzer has no loading left to do, giving up after `timeout`.
+    ///
+    /// Worth doing before anything whose answer is only right once rust-analyzer has seen the
+    /// whole workspace.
+    pub async fn wait_until_loaded(&self, timeout: Duration) -> bool {
+        let mut quiescent = self.quiescent.subscribe();
+        let wait = async {
+            loop {
+                if *quiescent.borrow_and_update() {
+                    return true;
+                }
+                if quiescent.changed().await.is_err() {
+                    return false;
+                }
+            }
+        };
+
+        tokio::time::timeout(timeout, wait).await.unwrap_or(false)
+    }
+
+    /// Everything known about `uri` as it stands: what rust-analyzer works out itself, asked for
+    /// afresh, and what the last cargo check said.
+    ///
+    /// The two halves have to be come by differently. rust-analyzer publishes its own analysis
+    /// when it gets round to it, and one worked out before a change can arrive after it -- but
+    /// the same analysis can simply be asked for, and the answer then describes the content
+    /// rust-analyzer holds rather than the content it held. Cargo's half cannot be asked for at
+    /// all: it exists only as the published results of a check, which is what the wait above is
+    /// for.
+    async fn current_diagnostics(&mut self, uri: &str) -> Result<Value> {
+        let published = self.published_diagnostics(uri).await;
+
+        let params = json!({ "textDocument": { "uri": uri } });
+        let pulled = match self
+            .send_request("textDocument/diagnostic", Some(params))
+            .await
+        {
+            Ok(pulled) => pulled,
+            // Asking is an improvement on waiting to be told, not a requirement: an older
+            // rust-analyzer, or one that has gone away, leaves the published reports as all
+            // there is.
+            Err(e) => {
+                warn!("Could not ask rust-analyzer about {}: {}", uri, e);
+                return Ok(json!(published));
+            }
+        };
+        let Some(analysed) = pulled.get("items").and_then(|items| items.as_array()) else {
+            return Ok(json!(published));
+        };
+
+        let from_cargo = published
+            .iter()
+            .filter(|diagnostic| diagnostic["source"] != ANALYSIS_SOURCE)
+            .cloned();
+
+        Ok(json!(analysed
+            .iter()
+            .cloned()
+            .chain(from_cargo)
+            .collect::<Vec<_>>()))
+    }
+
+    /// What rust-analyzer last published about `uri`, and nothing else.
+    ///
+    /// Unlike [`Self::diagnostics`] this does not fall back to asking rust-analyzer directly:
+    /// having waited for a check, no entry means the check had nothing to say about the file,
+    /// and the answer to that is an empty list rather than a request whose reply cannot contain
+    /// a cargo diagnostic anyway.
+    async fn published_diagnostics(&self, uri: &str) -> Vec<Value> {
+        self.diagnostics
+            .lock()
+            .await
+            .get(&uri::normalize(uri))
+            .cloned()
+            .unwrap_or_default()
     }
 
     pub async fn workspace_diagnostics(&mut self) -> Result<Value> {

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -247,40 +247,20 @@ async fn handle_diagnostics(server: &mut RustAnalyzerMCPServer, args: Value) -> 
 
     let uri = server.open_document_if_needed(&file_path).await?;
 
-    // Poll for diagnostics - rust-analyzer needs time to run cargo check.
-    // For files with expected errors (like diagnostics_test.rs), poll longer.
-    let should_poll = file_path.contains("diagnostics_test") || file_path.contains("simple_error");
-
     let Some(client) = &mut server.client else {
         return Err(anyhow!("Client not initialized"));
     };
 
-    let mut result = json!([]);
-    if should_poll {
-        let start = std::time::Instant::now();
-        let timeout = tokio::time::Duration::from_secs(8); // Less than test timeout.
-        let poll_interval = tokio::time::Duration::from_millis(500);
-
-        while start.elapsed() < timeout {
-            result = client.diagnostics(&uri).await?;
-            let Some(diag_array) = result.as_array() else {
-                tokio::time::sleep(poll_interval).await;
-                continue;
-            };
-
-            if !diag_array.is_empty() {
-                // We got diagnostics, stop polling.
-                break;
-            }
-            tokio::time::sleep(poll_interval).await;
-        }
-    } else {
-        // For clean files, just wait a bit and check once.
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-        result = client.diagnostics(&uri).await?;
+    let fresh = client.fresh_diagnostics(&uri).await?;
+    let mut diagnostics = format_diagnostics(&file_path, &fresh.items);
+    if !fresh.complete {
+        // Saying so beats either waiting longer or passing off what rust-analyzer had got to so
+        // far as the state of the code -- least of all when that is an empty list.
+        diagnostics["note"] = json!(
+            "rust-analyzer had not finished loading the workspace or checking it when this was \
+             reported, so these diagnostics may be incomplete. Ask again for the rest."
+        );
     }
-
-    let diagnostics = format_diagnostics(&file_path, &result);
 
     Ok(ToolResult {
         content: vec![ContentItem {

--- a/tests/integration/edits.rs
+++ b/tests/integration/edits.rs
@@ -53,3 +53,63 @@ async fn symbol_names(client: &MCPTestClient, file: &std::path::Path) -> Result<
         .filter_map(|symbol| Some(symbol.get("name")?.as_str()?.to_string()))
         .collect())
 }
+
+#[tokio::test]
+async fn diagnostics_follow_an_edit() -> Result<()> {
+    let project = IsolatedProject::new_diagnostics()?;
+    let errors = project.path().join("src/errors.rs");
+    let client = MCPTestClient::start(project.path()).await?;
+    client.initialize_and_wait().await?;
+
+    let mut before = diagnostics(&client, &errors).await?;
+    for _ in 0..5 {
+        if before["note"].is_null() {
+            break;
+        }
+        // rust-analyzer says it had not finished; asking again is what it asks for.
+        before = diagnostics(&client, &errors).await?;
+    }
+    assert!(
+        before["summary"]["errors"].as_u64().unwrap_or(0) > 0,
+        "the file is full of deliberate errors: {before}"
+    );
+
+    // The whole point of the tool, from an agent's side: fix what was reported, then ask again.
+    std::fs::write(
+        &errors,
+        "//! Every error this file had, fixed.\n\npub fn no_longer_broken() -> i32 {\n    42\n}\n",
+    )?;
+
+    // The tool says so itself when it could not wait a check out -- another workspace check was
+    // already running, say -- and asking again is what it asks for.
+    let mut after = diagnostics(&client, &errors).await?;
+    for _ in 0..5 {
+        if after["summary"]["errors"] == json!(0) || after["note"].is_null() {
+            break;
+        }
+        after = diagnostics(&client, &errors).await?;
+    }
+
+    assert_eq!(
+        after["summary"]["errors"].as_u64(),
+        Some(0),
+        "the errors were fixed, but the report still describes the old file: {after}"
+    );
+
+    client.shutdown().await
+}
+
+async fn diagnostics(client: &MCPTestClient, file: &std::path::Path) -> Result<Value> {
+    let response = client
+        .call_tool(
+            "rust_analyzer_diagnostics",
+            json!({ "file_path": file.to_str().unwrap() }),
+        )
+        .await?;
+
+    let text = response["content"][0]["text"]
+        .as_str()
+        .ok_or_else(|| anyhow!("No text in diagnostics response: {response}"))?;
+
+    Ok(serde_json::from_str(text)?)
+}


### PR DESCRIPTION
Closes #12 (with #30, merged, and #31). **Stacked on #31.**

## The bug

Whether `rust_analyzer_diagnostics` waited for anything was decided by:

```rust
let should_poll = file_path.contains("diagnostics_test") || file_path.contains("simple_error");
```

No file in this repository has matched that in a long time, so *every* call took the other branch: `sleep(2s)`, then return whatever happened to be in the published-diagnostics map. That is a report on the code as rust-analyzer last happened to see it — which, right after an edit, is the code as it was. #30 gets rust-analyzer the new content; this makes the tool wait for a report about it.

## What changed

**Wait for the workspace to load.** A file rust-analyzer hasn't reached yet looks exactly like a file with nothing wrong with it, so a report during loading can be an unqualified empty list. `fresh_diagnostics()` now waits for quiescence first (bounded).

**Cargo's half — wait for a check.** It asks for `rust-analyzer/runFlycheck` and waits for it. Waiting needs rust-analyzer to say what it's doing, so `initialize` declares `window.workDoneProgress` (without it `report_progress` returns early and sends nothing) and `connection.rs` follows the `$/progress` tokens under `rust-analyzer/flycheck/`. A check restarted while another runs *cancels* it, and a cancelled check ends exactly like a finished one — so the condition is "a check begun since the request, and none still running", not "an end arrived". There can be several checks (one per workspace), so the running ones are tracked as a set.

**rust-analyzer's own half — ask, don't wait.** This one caused a flaky failure I chased for a while: the analysis rust-analyzer publishes is whatever it last worked out, and an analysis begun before a change arrives *after* it, so the map could hold a description of the previous content even after a completed check. `textDocument/diagnostic` computes from the content rust-analyzer holds right now, so that half is pulled and the published entries are used only for what a check produced (`source != "rust-analyzer"`). If the request fails — older rust-analyzer, or one that has gone away — it falls back to the published entries.

**Bounded, and honest when it gives up.** A `runFlycheck` request is worked out on a task rust-analyzer abandons whenever its analysis is superseded (by the very change being asked about, among other things), so it can silently go nowhere; it is repeated a few times before giving up. Whenever any of the waits runs out, the result carries

```json
"note": "rust-analyzer had not finished loading the workspace or checking it when this was reported, so these diagnostics may be incomplete. Ask again for the rest."
```

rather than failing or passing what rust-analyzer had got to off as the state of the code.

Giving up on a rust-analyzer that reports no checks at all is not permanent (thanks for catching that): the skip applies only while no check has *ever* been reported, so the late first check on a big workspace puts the waiting back on the next call.

Removing the filename heuristic also removes the flat 2-second sleep every call used to pay.

## Tests

- `src/lsp/connection.rs`: the progress state machine — two concurrent checks, a cancelled-and-restarted check (which must *not* count as one that ran), and non-flycheck progress tokens being ignored.
- `src/lsp/client.rs`: a check is asked for and waited out; the analysis is asked for; a rust-analyzer that reports no checks comes back marked and isn't waited for again; **a check reported late puts the waiting back**; a report from a still-loading workspace is marked incomplete. All with `start_paused`, so no test waits on a real clock.
- `tests/integration/edits.rs::diagnostics_follow_an_edit`: with its own workspace, ask for diagnostics on a file full of deliberate errors, fix the file on disk, ask again, and assert the errors are gone.

I ran the whole suite repeatedly for this one — the earlier version passed alone and failed about half the time under the parallel load of the full run, which is what turned up the published-analysis staleness. `cargo test --workspace` (60 unit + 25 integration) and `cargo clippy -- -D warnings` are green.

## Note on `handle_request`'s dead paths

`RustAnalyzerClient::diagnostics()` still falls back to `textDocument/diagnostic` for `code_actions`, and `workspace_diagnostics()`'s `Err(_)` arm is unreachable (LSP errors are turned into `Ok(null)` before it can see them, and rust-analyzer has no `workspace/diagnostic` handler at all — the tool always reports "Unexpected response format"). Both are worth their own issue; I left them alone here.