### PR TITLE
✨ Run rust-analyzer with the cargo features asked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,45 @@ Add this to your Claude Desktop configuration (`claude_desktop_config.json`):
 **Note:** If installed from crates.io, the command will be in your PATH. For Claude Desktop, you
 may want to specify a `cwd` parameter if you want to analyze a specific project by default.
 
+### Cargo features
+
+By default rust-analyzer analyses and checks your crate with whatever features its manifest makes
+default, so code behind a feature gate looks unresolved and its errors go unreported. Pass the
+features to use on the command line:
+
+```bash
+rust-analyzer-mcp --all-features /path/to/project
+rust-analyzer-mcp --features serde,tokio /path/to/project
+rust-analyzer-mcp --no-default-features --features serde /path/to/project
+```
+
+In a workspace, a feature may need naming with the package it belongs to, exactly as cargo wants
+it: `--features my-crate/serde`.
+
+Which features to use is a choice worth making per project rather than everywhere: `--all-features`
+enables even the features a crate never expects to see enabled together, which for some projects
+means analysis that fails or takes far longer than it needs to. Options go in `args` alongside the
+command:
+
+```json
+{
+  "mcpServers": {
+    "rust-analyzer": {
+      "command": "rust-analyzer-mcp",
+      "args": ["--features", "serde,tokio"]
+    }
+  }
+}
+```
+
+Anything else rust-analyzer can be configured with is available through `--config`, which takes any
+[rust-analyzer setting](https://rust-analyzer.github.io/book/configuration.html) without the
+`rust-analyzer.` prefix. The value is read as JSON, or taken for a string if it is not JSON:
+
+```bash
+rust-analyzer-mcp --config check.command=clippy --config 'check.extraArgs=["--tests"]' .
+```
+
 ### Other MCP Clients
 
 For other MCP clients, run the server with:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,241 @@
+//! The command line this server is started with.
+
+use anyhow::{bail, Result};
+use std::{ffi::OsString, path::PathBuf};
+
+use crate::settings::Settings;
+
+pub const USAGE: &str = "\
+MCP server for rust-analyzer integration.
+
+Usage: rust-analyzer-mcp [OPTIONS] [--] [WORKSPACE]
+
+Arguments:
+  [WORKSPACE]  Path to the workspace root [default: current directory]
+
+Options:
+      --all-features         Analyse and check with every cargo feature enabled
+      --features <LIST>      Cargo features to enable, comma- or space-separated. May be given
+                             more than once
+      --no-default-features  Leave the manifest's default features out
+      --config <KEY=VALUE>   Set any rust-analyzer setting, such as --config check.command=clippy.
+                             VALUE is read as JSON, or taken for a string if it is not JSON. May
+                             be given more than once
+  -h, --help                 Print help
+  -V, --version              Print version
+";
+
+/// What a command line asks for.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Action {
+    Help,
+    Version,
+    Serve {
+        /// The workspace to analyse, if the command line named one.
+        workspace: Option<PathBuf>,
+        settings: Settings,
+    },
+}
+
+/// Reads `args`, which are the arguments after the program's own name.
+///
+/// Takes them as [`OsString`]s so that a workspace path that is not valid UTF-8 is passed
+/// through rather than rejected out of hand.
+pub fn parse(args: impl IntoIterator<Item = OsString>) -> Result<Action> {
+    let mut args = args.into_iter();
+    let mut workspace = None;
+    let mut settings = Settings::default();
+    let mut options_ended = false;
+
+    while let Some(arg) = args.next() {
+        // A lone "--" ends the options, which is how a workspace path that starts with '-' gets
+        // through.
+        if !options_ended && arg == "--" {
+            options_ended = true;
+            continue;
+        }
+
+        // Only an option can be required to be UTF-8; a path is whatever the filesystem says.
+        let option = (!options_ended)
+            .then(|| arg.to_str())
+            .flatten()
+            .filter(|arg| arg.starts_with('-'));
+        if let Some(option) = option {
+            // Both `--features a,b` and `--features=a,b` are how people write these.
+            let (name, inline) = match option.split_once('=') {
+                Some((name, value)) => (name, Some(value.to_string())),
+                None => (option, None),
+            };
+
+            match name {
+                "-h" | "--help" => return Ok(Action::Help),
+                "-V" | "--version" => return Ok(Action::Version),
+                "--all-features" => settings.enable_all_features()?,
+                "--no-default-features" => settings.disable_default_features()?,
+                "--features" => settings.enable_features(&value(name, inline, &mut args)?)?,
+                "--config" => settings.set(&value(name, inline, &mut args)?)?,
+                _ => bail!("unknown option '{option}'\n\n{USAGE}"),
+            }
+            continue;
+        }
+
+        if workspace.replace(PathBuf::from(&arg)).is_some() {
+            bail!(
+                "unexpected extra argument '{}'\n\n{USAGE}",
+                arg.to_string_lossy()
+            );
+        }
+    }
+
+    Ok(Action::Serve {
+        workspace,
+        settings,
+    })
+}
+
+/// The value of an option, whether it was written after an `=` or as the next argument.
+fn value(
+    name: &str,
+    inline: Option<String>,
+    args: &mut impl Iterator<Item = OsString>,
+) -> Result<String> {
+    if let Some(value) = inline {
+        return Ok(value);
+    }
+
+    let Some(value) = args.next() else {
+        bail!("{name} needs a value\n\n{USAGE}");
+    };
+    let Some(value) = value.to_str() else {
+        bail!("{name}'s value is not valid UTF-8");
+    };
+
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn nothing_at_all_serves_the_current_directory() {
+        assert_eq!(
+            parse([]).unwrap(),
+            Action::Serve {
+                workspace: None,
+                settings: Settings::default()
+            }
+        );
+    }
+
+    #[test]
+    fn help_and_version_win_over_everything_else() {
+        for asked in ["-h", "--help"] {
+            assert_eq!(parse(args(&[asked, "/ws"])).unwrap(), Action::Help);
+        }
+        for asked in ["-V", "--version"] {
+            assert_eq!(parse(args(&[asked])).unwrap(), Action::Version);
+        }
+    }
+
+    #[test]
+    fn the_workspace_is_whichever_argument_is_not_an_option() {
+        let Action::Serve { workspace, .. } = parse(args(&["--all-features", "/ws"])).unwrap()
+        else {
+            panic!("expected a workspace");
+        };
+
+        assert_eq!(workspace, Some(PathBuf::from("/ws")));
+    }
+
+    #[test]
+    fn a_workspace_can_be_named_after_the_options_end() {
+        let Action::Serve { workspace, .. } = parse(args(&["--", "-weird-name"])).unwrap() else {
+            panic!("expected a workspace");
+        };
+
+        assert_eq!(workspace, Some(PathBuf::from("-weird-name")));
+    }
+
+    #[test]
+    fn features_are_taken_either_way_round() {
+        for spelling in [
+            &["--features", "serde,tokio"][..],
+            &["--features=serde,tokio"][..],
+            &["--features", "serde", "--features", "tokio"][..],
+            &["--features", "serde tokio"][..],
+        ] {
+            assert_eq!(
+                settings_of(parse(args(spelling)).unwrap())["cargo"]["features"],
+                json!(["serde", "tokio"]),
+                "{spelling:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_feature_can_be_asked_for() {
+        let settings = settings_of(parse(args(&["--all-features"])).unwrap());
+
+        assert_eq!(settings["cargo"]["features"], json!("all"));
+    }
+
+    #[test]
+    fn defaults_can_be_left_out() {
+        let settings = settings_of(parse(args(&["--no-default-features"])).unwrap());
+
+        assert_eq!(settings["cargo"]["noDefaultFeatures"], json!(true));
+    }
+
+    #[test]
+    fn any_setting_can_be_named() {
+        let settings = settings_of(
+            parse(args(&[
+                "--config",
+                "check.command=clippy",
+                "--config=cargo.allTargets=false",
+            ]))
+            .unwrap(),
+        );
+
+        assert_eq!(settings["check"]["command"], json!("clippy"));
+        assert_eq!(settings["cargo"]["allTargets"], json!(false));
+    }
+
+    #[test]
+    fn a_command_line_that_makes_no_sense_says_so() {
+        for nonsense in [
+            &["--all-features", "--features", "serde"][..],
+            &["--features"][..],
+            &["--config"][..],
+            &["--config", "nonsense"][..],
+            &["--nope"][..],
+            &["/ws", "/other"][..],
+        ] {
+            assert!(parse(args(nonsense)).is_err(), "{nonsense:?}");
+        }
+    }
+
+    #[test]
+    fn an_option_after_the_options_ended_is_a_path() {
+        let Action::Serve { workspace, .. } = parse(args(&["--", "--all-features"])).unwrap()
+        else {
+            panic!("expected a workspace");
+        };
+
+        assert_eq!(workspace, Some(PathBuf::from("--all-features")));
+    }
+
+    fn args(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    fn settings_of(action: Action) -> serde_json::Value {
+        let Action::Serve { settings, .. } = action else {
+            panic!("expected a command line asking to serve");
+        };
+
+        settings.to_json()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod cli;
 pub mod config;
 pub mod diagnostics;
 pub mod lsp;
 pub mod mcp;
 pub mod protocol;
+pub mod settings;
 pub mod uri;
 
 pub use mcp::RustAnalyzerMCPServer;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -50,10 +50,13 @@ pub struct RustAnalyzerClient {
     pub(super) saved_documents: HashSet<String>,
     /// The task reading rust-analyzer's stdout; it finishing means rust-analyzer is gone.
     pub(super) reader: Option<JoinHandle<()>>,
+    /// What rust-analyzer was started with, and is handed again whenever it asks for its
+    /// configuration.
+    pub(super) settings: Value,
 }
 
 impl RustAnalyzerClient {
-    pub fn new(workspace_root: PathBuf) -> Self {
+    pub fn new(workspace_root: PathBuf, settings: Value) -> Self {
         let workspace_root = uri::absolute(&workspace_root);
 
         Self {
@@ -70,6 +73,7 @@ impl RustAnalyzerClient {
             gave_up_on_checks: false,
             saved_documents: HashSet::new(),
             reader: None,
+            settings,
         }
     }
 
@@ -78,6 +82,9 @@ impl RustAnalyzerClient {
             "Starting rust-analyzer process in workspace: {}",
             self.workspace_root.display()
         );
+        // rust-analyzer says nothing about settings it does not recognise, so a mistyped one is
+        // only ever findable here.
+        info!("rust-analyzer settings: {}", self.settings);
 
         // Clear any existing diagnostics from previous sessions.
         self.diagnostics.lock().await.clear();
@@ -139,7 +146,7 @@ impl RustAnalyzerClient {
                 quiescent: self.quiescent.clone(),
                 flycheck: self.flycheck.clone(),
                 outgoing: stdin,
-                settings: settings(),
+                settings: self.settings.clone(),
             },
         ));
 
@@ -151,7 +158,7 @@ impl RustAnalyzerClient {
 
         // Tell rust-analyzer its configuration changed. It ignores what comes with the
         // notification and asks for the settings itself, which the reader task answers.
-        let config_params = json!({ "settings": { "rust-analyzer": settings() } });
+        let config_params = json!({ "settings": { "rust-analyzer": self.settings } });
         let _ = self
             .send_notification("workspace/didChangeConfiguration", Some(config_params))
             .await;
@@ -234,7 +241,7 @@ impl RustAnalyzerClient {
         let init_params = json!({
             "processId": std::process::id(),
             "rootUri": uri::path_to_uri(&self.workspace_root)?,
-            "initializationOptions": settings(),
+            "initializationOptions": self.settings,
             "capabilities": {
                 "textDocument": {
                     "hover": {
@@ -458,34 +465,6 @@ impl RustAnalyzerClient {
     pub fn exit_status(&mut self) -> Option<ExitStatus> {
         self.process.as_mut()?.try_wait().ok().flatten()
     }
-}
-
-/// The configuration rust-analyzer is asked to run with.
-///
-/// Sent once as `initializationOptions`, and handed back whenever rust-analyzer asks for its
-/// configuration -- which it does, rather than reading the notification that told it to.
-fn settings() -> Value {
-    json!({
-        "cargo": {
-            "buildScripts": {
-                "enable": true
-            }
-        },
-        "checkOnSave": {
-            "enable": true,
-            "command": "check",
-            "allTargets": true
-        },
-        "diagnostics": {
-            "enable": true,
-            "experimental": {
-                "enable": true
-            }
-        },
-        "procMacro": {
-            "enable": true
-        }
-    })
 }
 
 /// What rust-analyzer was last told about a document, so that the next thing it is told about
@@ -756,7 +735,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn exit_status_reflects_whether_rust_analyzer_is_alive() {
-        let mut client = RustAnalyzerClient::new(PathBuf::from("."));
+        let mut client = RustAnalyzerClient::new(PathBuf::from("."), json!({}));
         // The shell lives until its stdin closes, then exits with 3.
         let mut child = Command::new("sh")
             .args(["-c", "read _; exit 3"])
@@ -778,7 +757,7 @@ mod tests {
 
     #[tokio::test]
     async fn is_gone_once_rust_analyzer_closes_its_stdout() {
-        let mut client = RustAnalyzerClient::new(PathBuf::from("."));
+        let mut client = RustAnalyzerClient::new(PathBuf::from("."), json!({}));
         let (stdout, rust_analyzer) = tokio::io::duplex(64);
         client.reader = Some(super::super::connection::start_handlers(
             stdout,
@@ -789,7 +768,7 @@ mod tests {
                 quiescent: client.quiescent.clone(),
                 flycheck: client.flycheck.clone(),
                 outgoing: Arc::new(Mutex::new(BufWriter::new(tokio::io::sink()))),
-                settings: settings(),
+                settings: json!({}),
             },
         ));
         tokio::task::yield_now().await;
@@ -805,7 +784,7 @@ mod tests {
 
     #[tokio::test]
     async fn workspace_diagnostics_fails_once_rust_analyzer_is_gone() {
-        let mut client = RustAnalyzerClient::new(PathBuf::from("."));
+        let mut client = RustAnalyzerClient::new(PathBuf::from("."), json!({}));
         let mut reader = tokio::spawn(async {});
         (&mut reader).await.unwrap();
         client.reader = Some(reader);
@@ -824,7 +803,7 @@ mod tests {
             .stdout(Stdio::piped())
             .spawn()
             .unwrap();
-        let mut client = RustAnalyzerClient::new(PathBuf::from("."));
+        let mut client = RustAnalyzerClient::new(PathBuf::from("."), json!({}));
         client.stdin = Some(Arc::new(Mutex::new(BufWriter::new(
             child.stdin.take().unwrap(),
         ))));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,58 +1,37 @@
-use anyhow::{bail, Result};
-use std::path::PathBuf;
+use anyhow::Result;
 
-use rust_analyzer_mcp::RustAnalyzerMCPServer;
-
-const USAGE: &str = "\
-MCP server for rust-analyzer integration.
-
-Usage: rust-analyzer-mcp [--] [WORKSPACE]
-
-Arguments:
-  [WORKSPACE]  Path to the workspace root [default: current directory]
-
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
-";
+use rust_analyzer_mcp::{
+    cli::{self, Action, USAGE},
+    RustAnalyzerMCPServer,
+};
 
 fn main() -> Result<()> {
     // Initialize logging.
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    // Get workspace path from command line or use current directory. args_os() instead of
-    // args() so a non-UTF-8 workspace path is passed through rather than panicking.
-    let mut args = std::env::args_os().skip(1);
-    let workspace_path = match args.next() {
-        // A lone "--" ends option parsing, allowing a workspace path that starts with '-'.
-        Some(arg) if arg == "--" => args.next().map(PathBuf::from),
-        Some(arg) => match arg.to_str() {
-            Some("--help") | Some("-h") => {
-                print!("{USAGE}");
-                return Ok(());
-            }
-            Some("--version") | Some("-V") => {
-                println!("rust-analyzer-mcp {}", env!("CARGO_PKG_VERSION"));
-                return Ok(());
-            }
-            Some(opt) if opt.starts_with('-') => bail!("unknown option '{opt}'\n\n{USAGE}"),
-            _ => Some(PathBuf::from(arg)),
-        },
-        None => None,
+    // args_os() rather than args() so a workspace path that is not valid UTF-8 is passed through
+    // rather than panicking.
+    let (workspace_path, settings) = match cli::parse(std::env::args_os().skip(1))? {
+        Action::Help => {
+            print!("{USAGE}");
+            return Ok(());
+        }
+        Action::Version => {
+            println!("rust-analyzer-mcp {}", env!("CARGO_PKG_VERSION"));
+            return Ok(());
+        }
+        Action::Serve {
+            workspace,
+            settings,
+        } => (workspace, settings),
     };
     let workspace_path = workspace_path
         .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
-    if let Some(extra) = args.next() {
-        bail!(
-            "unexpected extra argument '{}'\n\n{USAGE}",
-            extra.to_string_lossy()
-        );
-    }
 
     // Create and run the server, catching panics so an unwind cannot bypass the runtime
     // shutdown below. This only matters for debug builds and tests: release builds abort on
     // panic.
-    let mut server = RustAnalyzerMCPServer::with_workspace(workspace_path);
+    let mut server = RustAnalyzerMCPServer::with_workspace(workspace_path).with_settings(settings);
     let runtime = tokio::runtime::Runtime::new()?;
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         runtime.block_on(server.run())

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -7,12 +7,15 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use crate::{
     lsp::RustAnalyzerClient,
     protocol::mcp::{MCPError, MCPRequest, MCPResponse},
+    settings::Settings,
     uri,
 };
 
 pub struct RustAnalyzerMCPServer {
     pub(super) client: Option<RustAnalyzerClient>,
     pub(super) workspace_root: PathBuf,
+    /// What rust-analyzer is asked to run with, for every rust-analyzer this server starts.
+    pub(super) settings: Settings,
 }
 
 impl Default for RustAnalyzerMCPServer {
@@ -26,6 +29,7 @@ impl RustAnalyzerMCPServer {
         Self {
             client: None,
             workspace_root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            settings: Settings::default(),
         }
     }
 
@@ -33,7 +37,14 @@ impl RustAnalyzerMCPServer {
         Self {
             client: None,
             workspace_root: uri::absolute(&workspace_root),
+            settings: Settings::default(),
         }
+    }
+
+    /// Runs rust-analyzer with `settings`, whatever workspace it is pointed at.
+    pub fn with_settings(mut self, settings: Settings) -> Self {
+        self.settings = settings;
+        self
     }
 
     pub(super) async fn ensure_client_started(&mut self) -> Result<()> {
@@ -51,7 +62,8 @@ impl RustAnalyzerMCPServer {
         }
 
         if self.client.is_none() {
-            let mut client = RustAnalyzerClient::new(self.workspace_root.clone());
+            let mut client =
+                RustAnalyzerClient::new(self.workspace_root.clone(), self.settings.to_json());
             client.start().await?;
             self.client = Some(client);
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,253 @@
+//! The configuration rust-analyzer is asked to run with.
+//!
+//! rust-analyzer has no command line to speak of: everything it can be told is told to it over
+//! the LSP, as one JSON object. This is that object -- the settings this server always wants,
+//! with whatever the user asked for on top.
+
+use anyhow::{bail, Result};
+use serde_json::{json, Value};
+
+/// The cargo features to analyse and check with.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum Features {
+    /// Whatever the manifest makes default.
+    #[default]
+    Default,
+    /// All of them, which is `--all-features`.
+    All,
+    /// The named ones, in the spellings cargo takes: a bare feature name, or `package/feature`
+    /// in a workspace.
+    Named(Vec<String>),
+}
+
+/// Everything the command line has to say about how rust-analyzer should run.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Settings {
+    features: Features,
+    no_default_features: bool,
+    /// Settings named outright, as a path through the configuration and the value to put there.
+    overrides: Vec<(String, Value)>,
+}
+
+impl Settings {
+    /// Enables every feature.
+    pub fn enable_all_features(&mut self) -> Result<()> {
+        if self.features != Features::Default {
+            bail!("--all-features cannot be combined with --features");
+        }
+
+        self.features = Features::All;
+        Ok(())
+    }
+
+    /// Enables the features `list` names, comma- or space-separated.
+    pub fn enable_features(&mut self, list: &str) -> Result<()> {
+        let named: Vec<String> = list
+            .split([',', ' ', '\t'])
+            .filter(|feature| !feature.is_empty())
+            .map(str::to_string)
+            .collect();
+        if named.is_empty() {
+            bail!("--features needs at least one feature name");
+        }
+
+        match &mut self.features {
+            // rust-analyzer takes either every feature or a list, so the two cannot be asked for
+            // together: it would go with all of them and say nothing about the rest.
+            Features::All => bail!("--features cannot be combined with --all-features"),
+            Features::Named(features) => features.extend(named),
+            features @ Features::Default => *features = Features::Named(named),
+        }
+        Ok(())
+    }
+
+    /// Leaves the manifest's default features out.
+    pub fn disable_default_features(&mut self) -> Result<()> {
+        if self.features == Features::All {
+            bail!("--no-default-features cannot be combined with --all-features");
+        }
+
+        self.no_default_features = true;
+        Ok(())
+    }
+
+    /// Sets one rust-analyzer setting outright, from a `key.path=value` as it is spelled on the
+    /// command line.
+    ///
+    /// The value is read as JSON, and taken for a string when it is not any other JSON value --
+    /// so `check.command=clippy` means what it looks like it means.
+    pub fn set(&mut self, assignment: &str) -> Result<()> {
+        let Some((key, value)) = assignment.split_once('=') else {
+            bail!("--config needs a KEY=VALUE, such as check.command=clippy");
+        };
+        if key.is_empty() || key.split('.').any(str::is_empty) {
+            bail!("'{key}' is not a setting name");
+        }
+
+        let value = serde_json::from_str(value).unwrap_or_else(|_| json!(value));
+        self.overrides.push((key.to_string(), value));
+        Ok(())
+    }
+
+    /// The settings as rust-analyzer wants them.
+    pub fn to_json(&self) -> Value {
+        let mut settings = json!({
+            "cargo": {
+                "buildScripts": {
+                    "enable": true
+                }
+            },
+            "checkOnSave": true,
+            "diagnostics": {
+                "enable": true,
+                "experimental": {
+                    "enable": true
+                }
+            },
+            "procMacro": {
+                "enable": true
+            }
+        });
+
+        // `check.*` falls back to `cargo.*` for each of these, so setting them once covers both
+        // what rust-analyzer analyses and what cargo is asked to check.
+        match &self.features {
+            Features::Default => {}
+            Features::All => settings["cargo"]["features"] = json!("all"),
+            Features::Named(features) => settings["cargo"]["features"] = json!(features),
+        }
+        if self.no_default_features {
+            settings["cargo"]["noDefaultFeatures"] = json!(true);
+        }
+
+        for (key, value) in &self.overrides {
+            set_at(&mut settings, key, value.clone());
+        }
+
+        settings
+    }
+}
+
+/// Puts `value` at the dotted `key` in `settings`, making whatever objects it takes to get there.
+fn set_at(settings: &mut Value, key: &str, value: Value) {
+    let mut at = settings;
+    let mut names = key.split('.').peekable();
+
+    while let Some(name) = names.next() {
+        if names.peek().is_none() {
+            at[name] = value;
+            return;
+        }
+
+        // An override may name settings this server says nothing about, and may equally
+        // contradict one it does: either way what the user asked for wins.
+        if !at[name].is_object() {
+            at[name] = json!({});
+        }
+        at = &mut at[name];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_defaults_leave_features_to_the_manifest() {
+        let settings = Settings::default().to_json();
+
+        assert_eq!(settings["cargo"]["features"], Value::Null);
+        assert_eq!(settings["cargo"]["noDefaultFeatures"], Value::Null);
+    }
+
+    #[test]
+    fn all_features_is_the_word_rust_analyzer_knows() {
+        let mut settings = Settings::default();
+        settings.enable_all_features().unwrap();
+
+        // Lower case, and the bare string rather than a list containing it: a list would name a
+        // feature actually called "all".
+        assert_eq!(settings.to_json()["cargo"]["features"], json!("all"));
+    }
+
+    #[test]
+    fn features_are_named_one_by_one() {
+        let mut settings = Settings::default();
+        settings.enable_features("serde,tokio").unwrap();
+        settings.enable_features("other/thing  extra").unwrap();
+
+        assert_eq!(
+            settings.to_json()["cargo"]["features"],
+            json!(["serde", "tokio", "other/thing", "extra"])
+        );
+    }
+
+    #[test]
+    fn features_that_name_nothing_are_refused() {
+        assert!(Settings::default().enable_features("").is_err());
+        assert!(Settings::default().enable_features(" , ").is_err());
+    }
+
+    #[test]
+    fn all_features_cannot_be_narrowed() {
+        // rust-analyzer would quietly go with all of them; better to say so.
+        let mut settings = Settings::default();
+        settings.enable_all_features().unwrap();
+
+        assert!(settings.enable_features("serde").is_err());
+        assert!(settings.disable_default_features().is_err());
+
+        let mut settings = Settings::default();
+        settings.enable_features("serde").unwrap();
+        assert!(settings.enable_all_features().is_err());
+    }
+
+    #[test]
+    fn default_features_can_be_left_out() {
+        let mut settings = Settings::default();
+        settings.disable_default_features().unwrap();
+        settings.enable_features("serde").unwrap();
+
+        let settings = settings.to_json();
+        assert_eq!(settings["cargo"]["noDefaultFeatures"], json!(true));
+        assert_eq!(settings["cargo"]["features"], json!(["serde"]));
+    }
+
+    #[test]
+    fn any_setting_can_be_named_outright() {
+        let mut settings = Settings::default();
+        settings.set("check.command=clippy").unwrap();
+        settings
+            .set("cargo.target=x86_64-unknown-linux-gnu")
+            .unwrap();
+        settings.set("check.extraArgs=[\"--tests\"]").unwrap();
+        settings.set("procMacro.enable=false").unwrap();
+
+        let settings = settings.to_json();
+        assert_eq!(settings["check"]["command"], json!("clippy"));
+        assert_eq!(
+            settings["cargo"]["target"],
+            json!("x86_64-unknown-linux-gnu")
+        );
+        assert_eq!(settings["check"]["extraArgs"], json!(["--tests"]));
+        // Including one this server has an opinion about.
+        assert_eq!(settings["procMacro"]["enable"], json!(false));
+    }
+
+    #[test]
+    fn an_override_replaces_what_stands_in_its_way() {
+        let mut settings = Settings::default();
+        settings.set("checkOnSave.enable=true").unwrap();
+
+        // `checkOnSave` is a bare boolean by default, and a path through it has to make it an
+        // object rather than sit next to it.
+        assert_eq!(settings.to_json()["checkOnSave"], json!({ "enable": true }));
+    }
+
+    #[test]
+    fn settings_that_name_nothing_are_refused() {
+        assert!(Settings::default().set("check.command").is_err());
+        assert!(Settings::default().set("=clippy").is_err());
+        assert!(Settings::default().set("check..command=clippy").is_err());
+    }
+}

--- a/tests/integration/features.rs
+++ b/tests/integration/features.rs
@@ -1,0 +1,136 @@
+//! Tests that the cargo features named on the command line reach rust-analyzer.
+//!
+//! Nothing else here can tell: a feature-gated function is either analysed or invisible, and
+//! which of the two it is only shows in what rust-analyzer says about the code inside it.
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+use std::{path::PathBuf, process::Stdio, time::Duration};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::Command,
+};
+
+/// Long enough for a cold rust-analyzer to load a one-file crate and run a cargo check over it.
+const TIMEOUT: Duration = Duration::from_secs(120);
+
+/// A crate whose only mistake is behind a feature gate.
+const CRATE: &str = r#"
+#[cfg(feature = "extra")]
+pub fn only_with_extra() -> i32 {
+    let wrong: i32 = "not a number";
+    wrong
+}
+"#;
+
+#[tokio::test]
+async fn feature_gated_code_is_analysed_when_asked_for() -> Result<()> {
+    let project = feature_gated_crate()?;
+
+    let without = diagnostics(project.path(), &[]).await?;
+    assert_eq!(
+        without["summary"]["errors"], 0,
+        "the gated code is not part of the crate by default: {without}"
+    );
+
+    let with = diagnostics(project.path(), &["--all-features"]).await?;
+    assert!(
+        with["summary"]["errors"].as_u64().unwrap_or(0) > 0,
+        "--all-features must make the gated code count: {with}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_named_feature_is_analysed_too() -> Result<()> {
+    let project = feature_gated_crate()?;
+
+    let with = diagnostics(project.path(), &["--features", "extra"]).await?;
+
+    assert!(
+        with["summary"]["errors"].as_u64().unwrap_or(0) > 0,
+        "--features extra must make the gated code count: {with}"
+    );
+
+    Ok(())
+}
+
+/// Diagnostics for the crate's only file, from a server started with `options`.
+async fn diagnostics(workspace: &std::path::Path, options: &[&str]) -> Result<Value> {
+    let mut server = Command::new(server_binary()?)
+        .args(options)
+        .arg(workspace)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let mut stdin = server.stdin.take().expect("stdin was piped");
+    for message in [
+        r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}"#,
+        r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"rust_analyzer_diagnostics","arguments":{"file_path":"src/lib.rs"}}}"#,
+    ] {
+        stdin.write_all(message.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+    }
+    stdin.flush().await?;
+
+    let mut stdout = BufReader::new(server.stdout.take().expect("stdout was piped"));
+    let mut response = String::new();
+    tokio::time::timeout(TIMEOUT, async {
+        // The first line answers the initialize; the second carries the diagnostics.
+        for _ in 0..2 {
+            response.clear();
+            stdout.read_line(&mut response).await?;
+        }
+        Ok::<(), anyhow::Error>(())
+    })
+    .await
+    .map_err(|_| anyhow!("the server did not report diagnostics within {TIMEOUT:?}"))??;
+
+    let response: Value = serde_json::from_str(&response)?;
+    let text = response["result"]["content"][0]["text"]
+        .as_str()
+        .ok_or_else(|| anyhow!("No diagnostics in response: {response}"))?;
+
+    Ok(serde_json::from_str(text)?)
+}
+
+/// A crate with an `extra` feature, in a directory of its own.
+fn feature_gated_crate() -> Result<tempfile::TempDir> {
+    let project = tempfile::TempDir::new()?;
+    std::fs::write(
+        project.path().join("Cargo.toml"),
+        "[package]\nname = \"features\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+         [features]\nextra = []\n\n[workspace]\n",
+    )?;
+    std::fs::create_dir(project.path().join("src"))?;
+    std::fs::write(project.path().join("src/lib.rs"), CRATE)?;
+
+    Ok(project)
+}
+
+fn server_binary() -> Result<PathBuf> {
+    let target = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target");
+    let release = target.join("release/rust-analyzer-mcp");
+    let debug = target.join("debug/rust-analyzer-mcp");
+
+    // Prefer whichever matches the profile the tests themselves were built with.
+    let (first, second) = if cfg!(debug_assertions) {
+        (debug, release)
+    } else {
+        (release, debug)
+    };
+    if first.exists() {
+        return Ok(first);
+    }
+    if second.exists() {
+        return Ok(second);
+    }
+    Err(anyhow!(
+        "no rust-analyzer-mcp binary in {}; run `cargo build` first",
+        target.display()
+    ))
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,7 @@
 mod integration {
     mod diagnostics;
     mod edits;
+    mod features;
     mod mcp_server_test;
     mod notifications;
     mod shared_test;


### PR DESCRIPTION
Fixes #13. **Stacked on #32 → #31** — only for textual reasons (it rewrites the same `settings()`/`start()` lines those PRs touch); nothing in it depends on their behaviour.

## Why

Code behind a feature gate that isn't on is not part of the crate as far as rust-analyzer is concerned — no hover, no definitions, and no diagnostics about any of it. rust-analyzer takes its configuration over the LSP rather than from a command line, and this server sent it a fixed one, so there was no answer to the question in the issue.

## What it looks like

```
Options:
      --all-features         Analyse and check with every cargo feature enabled
      --features <LIST>      Cargo features to enable, comma- or space-separated. May be given
                             more than once
      --no-default-features  Leave the manifest's default features out
      --config <KEY=VALUE>   Set any rust-analyzer setting, such as --config check.command=clippy.
                             VALUE is read as JSON, or taken for a string if it is not JSON. May
                             be given more than once
```

The setup examples in the README stay default-neutral; the Cargo-features section is where the options are documented, and it says why the choice is per project — `--all-features` enables even features a crate never expects to see enabled together.

Details worth knowing:

- The features go into `cargo.features` / `cargo.noDefaultFeatures`, not `check.*`: the check settings fall back to the cargo ones, so this covers both what rust-analyzer analyses and what its `cargo check` checks, and it is also the spelling that works on rust-analyzer versions predating the `checkOnSave` → `check` rename.
- `--all-features` with `--features` or `--no-default-features` is refused rather than passed on — rust-analyzer would take all the features and silently ignore the rest.
- Features are split on commas *and* spaces and kept as separate list entries, because rust-analyzer splits each entry on `/` for the `package/feature` form; a joined `"a,b"` would break that.
- `--config` covers everything else (`check.command=clippy`, `cargo.target=…`, `check.extraArgs=["--tests"]`), so nobody has to wait for a flag. The value is parsed as JSON, or taken for a string when it isn't JSON.
- The composed settings are logged at startup: rust-analyzer says nothing at all about settings it doesn't recognise, so a typo would otherwise be undebuggable.

Argument parsing outgrew `main()` (it could only read one argument and had no way to express a flag), so it moved into `src/cli.rs` where it can be tested, with the settings it produces in `src/settings.rs`. `main.rs` is now just the dispatch.

## Tests

- `src/cli.rs`: 8 unit tests — `--features a,b` / `--features=a,b` / repeated / space-separated all reaching the same place, `--` ending the options, help and version winning, and every nonsensical command line being refused.
- `src/settings.rs`: 9 unit tests — the `"all"` literal being the lowercase bare string (a list would name a feature *called* `all`), features accumulating, the refused combinations, and `--config` creating paths through the settings and overriding what this server would otherwise say.
- `tests/integration/features.rs`: builds a throwaway crate whose only mistake is behind a feature gate, and checks the tool reports 0 errors by default and errors with `--all-features` and with `--features extra`. That is the whole issue in one assertion.

Verified by hand too, against the shipped rust-analyzer:

```
--- default features ---   {'errors': 0, 'hints': 1, 'warnings': 0}
--- all features ---       {'errors': 2, 'hints': 1, 'warnings': 0}
```

`cargo test --workspace` (60 unit + 25 integration) and `cargo clippy -- -D warnings` are green.

## One behaviour change worth flagging

The `checkOnSave` object the server used to send (`{enable, command, allTargets}`) is now just `checkOnSave: true`. In current rust-analyzer that setting is a boolean, and every value in the old object restated a default — it survived only through deprecated aliases.