### PR TITLE
✨ mcp: Add a tool for renaming a symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,21 @@ Get all diagnostics across the entire workspace.
 Returns aggregated diagnostics for all files in the workspace with file paths, severity levels,
 messages, and a summary of total counts by severity.
 
+#### `rust_analyzer_rename`
+Rename the symbol at a position, everywhere it is used in the workspace.
+
+**Parameters:**
+- `file_path`: Path to the Rust file
+- `line`: Line number (0-based)
+- `character`: Character position (0-based)
+- `new_name`: The new name
+
+Changes no files. It returns the edits to apply, each with the byte range it covers and the text it
+replaces, listed last-first within each file so they can be applied one after another without
+adjusting for the ones already made. It fails rather than answering while rust-analyzer is still
+loading the workspace, since a rename worked out before then could miss references. Renaming a module also renames its file, which is reported
+under `file_operations`; the untouched LSP `WorkspaceEdit` is included as `workspace_edit`.
+
 ### `rust_analyzer_set_workspace`
 Change the workspace root directory.
 
@@ -367,7 +382,7 @@ cargo run --release
 
 This is a foundation implementation that covers the most common rust-analyzer features. Contributions are welcome for:
 
-- Additional LSP methods (workspace symbols, rename, etc.)
+- Additional LSP methods (workspace symbols, call hierarchy, etc.)
 - Better error handling and diagnostics  
 - Configuration options (via CLI args or config files)
 - Performance optimizations and async improvements

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod diagnostics;
 pub mod lsp;
 pub mod mcp;
+pub mod position;
 pub mod protocol;
 pub mod settings;
 pub mod uri;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -24,14 +24,14 @@ use crate::{
     uri,
 };
 
-use super::connection::{send_message, Connection, Diagnostics, Flycheck, Outgoing};
+use super::connection::{send_message, Connection, Diagnostics, Flycheck, Outgoing, Pending};
 
 pub struct RustAnalyzerClient {
     pub(super) process: Option<Child>,
     pub(super) request_id: Arc<Mutex<u64>>,
     pub(super) workspace_root: PathBuf,
     pub(super) stdin: Option<Outgoing<tokio::process::ChildStdin>>,
-    pub(super) pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
+    pub(super) pending_requests: Pending,
     pub(super) initialized: bool,
     /// What rust-analyzer was last told about each open document, keyed by normalized URI.
     pub(super) open_documents: Arc<Mutex<HashMap<String, OpenDocument>>>,
@@ -228,7 +228,8 @@ impl RustAnalyzerClient {
         // Wait for response with timeout. The channel only closes unanswered when the reader
         // task gave up on rust-analyzer's stdout, i.e. rust-analyzer is gone.
         match tokio::time::timeout(Duration::from_secs(LSP_REQUEST_TIMEOUT_SECS), rx).await {
-            Ok(response) => response.map_err(|_| anyhow!("rust-analyzer exited before responding")),
+            Ok(Ok(answer)) => answer.map_err(|message| anyhow!("{message}")),
+            Ok(Err(_)) => Err(anyhow!("rust-analyzer exited before responding")),
             Err(_) => {
                 // Unregister so an abandoned request cannot leak its pending entry.
                 pending_requests.lock().await.remove(&id);

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -187,11 +187,35 @@ impl RustAnalyzerClient {
         send_message(stdin, &notification).await
     }
 
+    /// Asks rust-analyzer something and waits for its answer.
+    ///
+    /// A request whose analysis is superseded while rust-analyzer is working on it comes back
+    /// refused rather than answered -- that is what "content modified" means -- and every
+    /// notification this server sends can do that to a request in flight. It means ask again.
     pub(super) async fn send_request(
         &mut self,
         method: &str,
         params: Option<Value>,
     ) -> Result<Value> {
+        for attempt in 1..REQUEST_ATTEMPTS {
+            let answer = self.send_request_once(method, params.clone()).await;
+            let Err(e) = &answer else {
+                return answer;
+            };
+            if !superseded(e) {
+                return answer;
+            }
+
+            info!(
+                "Asking rust-analyzer for {} again ({}): {}",
+                method, attempt, e
+            );
+        }
+
+        self.send_request_once(method, params).await
+    }
+
+    async fn send_request_once(&mut self, method: &str, params: Option<Value>) -> Result<Value> {
         let mut request_id_lock = self.request_id.lock().await;
         let id = *request_id_lock;
         *request_id_lock += 1;
@@ -282,12 +306,28 @@ impl RustAnalyzerClient {
                             "valueSet": [1, 2]
                         }
                     },
-                    "formatting": {}
+                    "formatting": {},
+                    "rename": {
+                        "dynamicRegistration": false,
+                        "prepareSupport": true
+                    }
                 },
                 "workspace": {
                     "didChangeConfiguration": {
                         "dynamicRegistration": false
+                    },
+                    // Renaming a module renames its file, which rust-analyzer refuses to work
+                    // out at all for a client that has not said it understands file operations.
+                    "workspaceEdit": {
+                        "documentChanges": true,
+                        "resourceOperations": ["create", "rename", "delete"],
+                        "failureHandling": "abort"
                     }
+                },
+                // The default, stated outright because every position in every result is counted
+                // this way and the tools say so.
+                "general": {
+                    "positionEncodings": ["utf-16"]
                 },
                 // Opt into the progress reports rust-analyzer gives on its background work,
                 // the cargo checks above all. It stays silent about all of it otherwise.
@@ -419,6 +459,32 @@ impl RustAnalyzerClient {
         Ok(())
     }
 
+    /// Tells rust-analyzer to stop taking this document's content from us.
+    ///
+    /// What is on disk becomes the truth about it again, which for a file that is no longer
+    /// there means it stops existing rather than lingering in rust-analyzer as it last was.
+    pub async fn close_document(&mut self, uri: &str) -> Result<()> {
+        let key = uri::normalize(uri);
+        if self.open_documents.lock().await.remove(&key).is_none() {
+            return Ok(());
+        }
+
+        info!("Closing document: {}", uri);
+        let params = json!({ "textDocument": { "uri": uri } });
+        self.send_notification("textDocument/didClose", Some(params))
+            .await?;
+
+        self.saved_documents.remove(&key);
+        self.diagnostics.lock().await.remove(&key);
+
+        Ok(())
+    }
+
+    /// The documents rust-analyzer has been told about, by URI.
+    pub async fn open_document_uris(&self) -> Vec<String> {
+        self.open_documents.lock().await.keys().cloned().collect()
+    }
+
     /// Shuts rust-analyzer down, attempting the graceful LSP handshake first.
     pub async fn shutdown(&mut self) -> Result<()> {
         if self.initialized {
@@ -478,6 +544,17 @@ pub(super) struct OpenDocument {
     /// hash rather than the content itself: an agent works its way through a lot of files, and
     /// nothing here needs the old text back.
     content_hash: u64,
+}
+
+/// How many times to ask for something rust-analyzer abandoned mid-request.
+const REQUEST_ATTEMPTS: u32 = 3;
+
+/// Whether rust-analyzer abandoned a request because what it was working from changed under it.
+fn superseded(error: &anyhow::Error) -> bool {
+    error
+        .to_string()
+        .to_lowercase()
+        .contains("content modified")
 }
 
 /// The version a document is opened at, which every later change counts up from.

--- a/src/lsp/connection.rs
+++ b/src/lsp/connection.rs
@@ -18,6 +18,12 @@ use crate::{protocol::lsp::LSPResponse, uri};
 /// What rust-analyzer has published about each document, by normalized URI.
 pub type Diagnostics = Arc<Mutex<HashMap<String, Vec<Value>>>>;
 
+/// What a request to rust-analyzer comes back with: its result, or what it says went wrong.
+pub type Answer = std::result::Result<Value, String>;
+
+/// The requests waiting for an answer, by the id each was sent under.
+pub type Pending = Arc<Mutex<HashMap<u64, oneshot::Sender<Answer>>>>;
+
 /// The cargo checks rust-analyzer has run, as reported by its progress notifications.
 ///
 /// A check is the only thing that produces the diagnostics rustc gives, so knowing whether one
@@ -90,7 +96,7 @@ pub async fn send_message<W: AsyncWrite + Unpin>(
 /// and everything they answer one with.
 pub struct Connection<W> {
     /// The requests waiting for an answer, by the id each was sent under.
-    pub pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
+    pub pending_requests: Pending,
     /// The last diagnostics published for each document.
     pub diagnostics: Diagnostics,
     /// Whether rust-analyzer has any background work in flight.
@@ -226,10 +232,7 @@ async fn handle_lsp_message<W: AsyncWrite + Unpin>(json_buffer: &[u8], connectio
     }
 }
 
-async fn handle_response(
-    json_value: Value,
-    pending: &Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
-) {
+async fn handle_response(json_value: Value, pending: &Pending) {
     let Ok(response) = serde_json::from_value::<LSPResponse>(json_value) else {
         return;
     };
@@ -245,12 +248,23 @@ async fn handle_response(
 
     if let Some(error) = response.error {
         error!("LSP error for request {}: {}", id, error);
-        let _ = sender.send(json!(null));
+        // What rust-analyzer refused to do and why is the answer, and often the only useful one:
+        // "Invalid name `1`: not an identifier" tells whoever asked what to do about it, where a
+        // bare nothing leaves them guessing at a rename that quietly did nothing.
+        let _ = sender.send(Err(message_of(&error)));
     } else {
         let result = response.result.unwrap_or(json!(null));
         info!("Sending result for request {}: {:?}", id, result);
-        let _ = sender.send(result);
+        let _ = sender.send(Ok(result));
     }
+}
+
+/// What an LSP error says, which is its `message` unless it is shaped unexpectedly.
+fn message_of(error: &Value) -> String {
+    error
+        .get("message")
+        .and_then(|message| message.as_str())
+        .map_or_else(|| error.to_string(), str::to_string)
 }
 
 /// Answers a request rust-analyzer made of us.
@@ -577,6 +591,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn what_rust_analyzer_refused_to_do_reaches_whoever_asked() {
+        // A bare "no" is indistinguishable from a request that did nothing; the reason is the
+        // whole of the answer for anything the user got wrong.
+        let (connection, _rust_analyzer) = connection();
+        let (sender, response) = oneshot::channel();
+        connection.pending_requests.lock().await.insert(1, sender);
+
+        deliver(
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": { "code": -32602, "message": "Invalid name `1`: not an identifier" }
+            }),
+            &connection,
+        )
+        .await;
+
+        assert_eq!(
+            response.await.unwrap(),
+            Err("Invalid name `1`: not an identifier".to_string())
+        );
+    }
+
+    #[tokio::test]
     async fn answers_still_reach_whoever_is_waiting() {
         let (connection, _rust_analyzer) = connection();
         let (sender, response) = oneshot::channel();
@@ -588,7 +626,10 @@ mod tests {
         )
         .await;
 
-        assert_eq!(response.await.unwrap(), json!({ "contents": "docs" }));
+        assert_eq!(
+            response.await.unwrap().unwrap(),
+            json!({ "contents": "docs" })
+        );
         assert!(connection.pending_requests.lock().await.is_empty());
     }
 

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -87,6 +87,38 @@ impl RustAnalyzerClient {
             .await
     }
 
+    /// Asks what renaming the symbol at a position would take, without doing any of it.
+    pub async fn rename(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+        new_name: &str,
+    ) -> Result<Value> {
+        let params = json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "newName": new_name
+        });
+
+        self.send_request("textDocument/rename", Some(params)).await
+    }
+
+    /// The range of the symbol a rename at this position would be about.
+    ///
+    /// Asked before a rename for two reasons: it says what is about to be renamed, which is worth
+    /// reporting back, and when there is nothing renameable there it says so more precisely than
+    /// the rename itself does.
+    pub async fn prepare_rename(&mut self, uri: &str, line: u32, character: u32) -> Result<Value> {
+        let params = json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character }
+        });
+
+        self.send_request("textDocument/prepareRename", Some(params))
+            .await
+    }
+
     pub async fn document_symbols(&mut self, uri: &str) -> Result<Value> {
         let params = json!({
             "textDocument": { "uri": uri }

--- a/src/mcp/handlers.rs
+++ b/src/mcp/handlers.rs
@@ -1,10 +1,15 @@
 use anyhow::{anyhow, Result};
 use log::debug;
 use serde_json::{json, Value};
-use std::path::Path;
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use crate::{
+    config::WORKSPACE_LOAD_TIMEOUT_SECS,
     diagnostics::format_diagnostics,
+    position,
     protocol::mcp::{ContentItem, ToolResult},
     uri,
 };
@@ -59,6 +64,7 @@ pub async fn handle_tool_call(
         "rust_analyzer_symbols" => handle_symbols(server, args).await,
         "rust_analyzer_format" => handle_format(server, args).await,
         "rust_analyzer_code_actions" => handle_code_actions(server, args).await,
+        "rust_analyzer_rename" => handle_rename(server, args).await,
         "rust_analyzer_set_workspace" => handle_set_workspace(server, args).await,
         "rust_analyzer_diagnostics" => handle_diagnostics(server, args).await,
         "rust_analyzer_workspace_diagnostics" => handle_workspace_diagnostics(server, args).await,
@@ -210,6 +216,225 @@ async fn handle_code_actions(
             text: serde_json::to_string_pretty(&result)?,
         }],
     })
+}
+
+async fn handle_rename(server: &mut RustAnalyzerMCPServer, args: Value) -> Result<ToolResult> {
+    let file_path = ToolParams::extract_file_path(&args)?;
+    let (line, character) = ToolParams::extract_position(&args)?;
+    let Some(new_name) = args["new_name"].as_str() else {
+        return Err(anyhow!("Missing new_name"));
+    };
+
+    let uri = server.open_document_if_needed(&file_path).await?;
+    // A rename is worked out across every file rust-analyzer holds, so every one of them has to
+    // be the file that is actually there.
+    server.refresh_open_documents().await?;
+
+    let Some(client) = &mut server.client else {
+        return Err(anyhow!("Client not initialized"));
+    };
+
+    // A rename is worked out from everything rust-analyzer has loaded, so one worked out while
+    // it is still loading can miss the references it has not reached yet -- and half a rename
+    // applied leaves the code worse than it was found. There is no reporting that with the
+    // edits, either: whoever asked would have every reason to take them for the whole rename.
+    if !client
+        .wait_until_loaded(Duration::from_secs(WORKSPACE_LOAD_TIMEOUT_SECS))
+        .await
+    {
+        return Err(anyhow!(
+            "rust-analyzer is still loading the workspace after {}s. A rename worked out now \
+             could miss references, so it is not worth having; ask again once it has settled.",
+            WORKSPACE_LOAD_TIMEOUT_SECS
+        ));
+    }
+
+    // What is about to be renamed is asked for first: its answer names the symbol, and it
+    // explains a position with nothing to rename at it better than the rename itself would.
+    let renaming = client.prepare_rename(&uri, line, character).await?;
+    let edit = client.rename(&uri, line, character, new_name).await?;
+    if edit.is_null() {
+        return Err(anyhow!(
+            "Nothing to rename at {}:{}:{}",
+            file_path,
+            line,
+            character
+        ));
+    }
+
+    let old_name = renamed_symbol(server, &file_path, &renaming).await;
+    let result = describe_rename(&edit, old_name, new_name).await;
+
+    Ok(ToolResult {
+        content: vec![ContentItem {
+            content_type: "text".to_string(),
+            text: serde_json::to_string_pretty(&result)?,
+        }],
+    })
+}
+
+/// The text `prepareRename` pointed at, which is the name being replaced.
+async fn renamed_symbol(
+    server: &RustAnalyzerMCPServer,
+    file_path: &str,
+    renaming: &Value,
+) -> Option<String> {
+    // rust-analyzer answers with a bare range; the specification also allows one wrapped
+    // alongside a placeholder.
+    let range = renaming.get("range").unwrap_or(renaming);
+    let content = tokio::fs::read_to_string(server.resolve_path(file_path))
+        .await
+        .ok()?;
+
+    Some(text_of(&content, range)?.to_string())
+}
+
+/// An account of a workspace edit that can be applied without working any of it out again.
+async fn describe_rename(edit: &Value, old_name: Option<String>, new_name: &str) -> Value {
+    let mut changes = Vec::new();
+    let mut file_operations = Vec::new();
+    let mut edit_count = 0;
+
+    for change in document_changes(edit) {
+        match change {
+            Change::Text { uri, edits } => {
+                let path = uri::uri_to_path(&uri);
+                let content = match &path {
+                    Some(path) => tokio::fs::read_to_string(path).await.ok(),
+                    None => None,
+                };
+
+                let mut edits: Vec<Value> = edits
+                    .iter()
+                    .map(|edit| describe_edit(edit, content.as_deref()))
+                    .collect();
+                // Descending, so that applying them one after another needs no arithmetic: every
+                // edit's range still means what it says once the ones after it have been made.
+                edits.sort_by_key(|edit| {
+                    std::cmp::Reverse((
+                        edit["line"].as_u64().unwrap_or(0),
+                        edit["character"].as_u64().unwrap_or(0),
+                    ))
+                });
+
+                edit_count += edits.len();
+                changes.push(json!({
+                    "file": display_path(&path, &uri),
+                    "edits": edits,
+                }));
+            }
+            Change::Resource(operation) => file_operations.push(operation),
+        }
+    }
+
+    json!({
+        "applied": false,
+        "old_name": old_name,
+        "new_name": new_name,
+        "position_encoding": "utf-16",
+        "summary": {
+            "files_changed": changes.len(),
+            "edits": edit_count,
+            "file_operations": file_operations.len(),
+        },
+        "changes": changes,
+        "file_operations": file_operations,
+        // Everything above is this, worked out. Whoever would rather work it out themselves can.
+        "workspace_edit": edit,
+    })
+}
+
+/// One entry of a workspace edit.
+enum Change {
+    /// Edits to one file.
+    Text { uri: String, edits: Vec<Value> },
+    /// Something done to a file itself, such as the rename of a module's file.
+    Resource(Value),
+}
+
+/// The changes a workspace edit is made of, however it spells them.
+fn document_changes(edit: &Value) -> Vec<Change> {
+    // `documentChanges` is what a client that understands file operations gets, and the only
+    // form that can carry them; `changes` is the older shape, kept for the rust-analyzer that
+    // answers with it.
+    if let Some(document_changes) = edit.get("documentChanges").and_then(|it| it.as_array()) {
+        return document_changes
+            .iter()
+            .map(
+                |change| match change.get("edits").and_then(|it| it.as_array()) {
+                    Some(edits) => Change::Text {
+                        uri: change["textDocument"]["uri"]
+                            .as_str()
+                            .unwrap_or_default()
+                            .to_string(),
+                        edits: edits.clone(),
+                    },
+                    None => Change::Resource(change.clone()),
+                },
+            )
+            .collect();
+    }
+
+    edit.get("changes")
+        .and_then(|it| it.as_object())
+        .map(|changes| {
+            changes
+                .iter()
+                .map(|(uri, edits)| Change::Text {
+                    uri: uri.clone(),
+                    edits: edits.as_array().cloned().unwrap_or_default(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// One text edit, with the offsets and the text it replaces spelled out.
+fn describe_edit(edit: &Value, content: Option<&str>) -> Value {
+    let range = edit.get("range").cloned().unwrap_or(json!(null));
+    let mut described = json!({
+        "line": range["start"]["line"],
+        "character": range["start"]["character"],
+        "end_line": range["end"]["line"],
+        "end_character": range["end"]["character"],
+        "new_text": edit.get("newText").cloned().unwrap_or(json!("")),
+    });
+
+    // Byte offsets and the text being replaced, so that an edit can be applied to the file as
+    // bytes and checked before it is: the columns above are UTF-16 code units, which are neither.
+    if let Some(content) = content {
+        if let Some((start, end)) = byte_range(content, &range) {
+            described["byte_range"] = json!([start, end]);
+            described["old_text"] = json!(&content[start..end]);
+        }
+    }
+
+    described
+}
+
+/// What `range` covers in `content`.
+fn text_of<'a>(content: &'a str, range: &Value) -> Option<&'a str> {
+    let (start, end) = byte_range(content, range)?;
+
+    Some(&content[start..end])
+}
+
+/// The byte offsets `range` covers in `content`.
+fn byte_range(content: &str, range: &Value) -> Option<(usize, usize)> {
+    let at = |end: &str, of: &str| -> Option<u32> {
+        range.get(end)?.get(of)?.as_u64().map(|it| it as u32)
+    };
+
+    let start = position::byte_offset(content, at("start", "line")?, at("start", "character")?);
+    let end = position::byte_offset(content, at("end", "line")?, at("end", "character")?);
+
+    (start <= end).then_some((start, end))
+}
+
+/// The path a URI names, or the URI itself when it names none.
+fn display_path(path: &Option<PathBuf>, uri: &str) -> String {
+    path.as_ref()
+        .map_or_else(|| uri.to_string(), |path| path.display().to_string())
 }
 
 async fn handle_set_workspace(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -85,6 +85,32 @@ impl RustAnalyzerMCPServer {
         Ok(uri)
     }
 
+    /// Brings rust-analyzer up to date with every document it has been told about.
+    ///
+    /// One document at a time is enough for a question about one file, but a rename reaches
+    /// across the workspace and is worked out from whatever rust-analyzer holds for each file it
+    /// touches. Anything stale in there comes back as an edit to a line that has moved.
+    pub(super) async fn refresh_open_documents(&mut self) -> Result<()> {
+        let Some(client) = &mut self.client else {
+            return Err(anyhow::anyhow!("Client not initialized"));
+        };
+
+        for uri in client.open_document_uris().await {
+            let Some(path) = uri::uri_to_path(&uri) else {
+                continue;
+            };
+
+            match tokio::fs::read_to_string(&path).await {
+                Ok(content) => client.open_document(&uri, &content).await?,
+                // Gone from disk, which a rename of a module's file does to it. Left open, it
+                // would go on existing as far as rust-analyzer is concerned.
+                Err(_) => client.close_document(&uri).await?,
+            }
+        }
+
+        Ok(())
+    }
+
     /// The file a tool call's `file_path` argument names.
     ///
     /// Clients spell that argument every way they have one to hand: relative to the workspace

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -95,6 +95,27 @@ pub fn get_tools() -> Vec<ToolDefinition> {
             }),
         },
         ToolDefinition {
+            name: "rust_analyzer_rename".to_string(),
+            description: "Rename the Rust symbol at a position and return the edits that carry \
+                          the rename out across the whole workspace. Changes no files: apply the \
+                          returned edits yourself. Renaming a module also renames its file, \
+                          which is reported under file_operations. Fails with an explanation if \
+                          there is nothing renameable at the position or the symbol is defined \
+                          in a dependency, or if rust-analyzer has not finished loading the \
+                          workspace -- a rename worked out before then could miss references."
+                .to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "file_path": { "type": "string", "description": "Path to the Rust file: relative to the workspace root, absolute, or a file:// URI" },
+                    "line": { "type": "number", "description": "Line number (0-based)" },
+                    "character": { "type": "number", "description": "Character position (0-based)" },
+                    "new_name": { "type": "string", "description": "The new name. For a lifetime, include the leading apostrophe" }
+                },
+                "required": ["file_path", "line", "character", "new_name"]
+            }),
+        },
+        ToolDefinition {
             name: "rust_analyzer_set_workspace".to_string(),
             description: "Set the workspace root directory for rust-analyzer".to_string(),
             input_schema: json!({

--- a/src/position.rs
+++ b/src/position.rs
@@ -1,0 +1,101 @@
+//! Turning the positions the LSP speaks in into offsets into a file.
+//!
+//! A position is a line and a column, both counted from zero, and the column is counted in
+//! UTF-16 code units -- not bytes, and not characters. For a line of ASCII all three agree, which
+//! is why the difference is easy to miss and unforgiving when it bites: on a line with an
+//! accented letter the byte offset runs ahead, and on one with an emoji the UTF-16 count does.
+
+/// The byte offset of the LSP position (`line`, `character`) in `text`.
+///
+/// A position past the end of its line, or past the end of the text, gives the end of what it
+/// points into: that is what editors do with one, and it keeps a rounding error in whoever asked
+/// from becoming a panic here.
+pub fn byte_offset(text: &str, line: u32, character: u32) -> usize {
+    let mut offset = 0;
+
+    for (number, line_text) in text.split_inclusive('\n').enumerate() {
+        if number as u32 == line {
+            return offset + column_offset(line_text, character);
+        }
+        offset += line_text.len();
+    }
+
+    // Past the last line, which a range ending at the end of the file does.
+    text.len()
+}
+
+/// The byte offset of `character`, counted in UTF-16 code units, into one line.
+fn column_offset(line: &str, character: u32) -> usize {
+    let line = line.strip_suffix('\n').unwrap_or(line);
+    let line = line.strip_suffix('\r').unwrap_or(line);
+
+    let mut counted = 0;
+    for (offset, character_here) in line.char_indices() {
+        if counted >= character {
+            return offset;
+        }
+
+        // A column that lands inside a character -- half an emoji -- is not an offset into
+        // anything, so it points at the character it landed in.
+        let after = counted + character_here.len_utf16() as u32;
+        if after > character {
+            return offset;
+        }
+        counted = after;
+    }
+
+    line.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEXT: &str = "fn main() {\n    let x = 1;\n}\n";
+
+    #[test]
+    fn a_position_is_a_line_and_a_column() {
+        assert_eq!(byte_offset(TEXT, 0, 0), 0);
+        assert_eq!(byte_offset(TEXT, 0, 3), 3);
+        assert_eq!(byte_offset(TEXT, 1, 4), "fn main() {\n    ".len());
+        assert_eq!(byte_offset(TEXT, 2, 0), TEXT.len() - 2);
+    }
+
+    #[test]
+    fn columns_are_counted_in_utf16_code_units() {
+        // `é` is one code unit and two bytes; `🦀` is two code units and four bytes.
+        let text = "let é = \"🦀\";";
+
+        assert_eq!(byte_offset(text, 0, 4), "let ".len());
+        assert_eq!(byte_offset(text, 0, 5), "let é".len());
+        assert_eq!(byte_offset(text, 0, 9), "let é = \"".len());
+        // The crab is two code units wide and four bytes long.
+        assert_eq!(byte_offset(text, 0, 11), "let é = \"🦀".len());
+    }
+
+    #[test]
+    fn a_column_inside_a_character_stops_before_it() {
+        // Half an emoji is not an offset; the character it lands in is where it points.
+        let text = "🦀🦀";
+
+        assert_eq!(byte_offset(text, 0, 1), 0);
+        assert_eq!(byte_offset(text, 0, 2), "🦀".len());
+        assert_eq!(byte_offset(text, 0, 3), "🦀".len());
+    }
+
+    #[test]
+    fn a_position_past_the_end_is_the_end() {
+        assert_eq!(byte_offset(TEXT, 0, 999), "fn main() {".len());
+        assert_eq!(byte_offset(TEXT, 99, 0), TEXT.len());
+        assert_eq!(byte_offset("", 0, 0), 0);
+    }
+
+    #[test]
+    fn line_endings_are_not_part_of_the_line() {
+        let text = "one\r\ntwo\r\n";
+
+        assert_eq!(byte_offset(text, 0, 99), "one".len());
+        assert_eq!(byte_offset(text, 1, 0), "one\r\n".len());
+        assert_eq!(byte_offset(text, 1, 3), "one\r\ntwo".len());
+    }
+}

--- a/test-support/src/ipc/client.rs
+++ b/test-support/src/ipc/client.rs
@@ -43,7 +43,10 @@ impl IpcClient {
     pub async fn get_or_create(project_type: &str) -> Result<Self> {
         // Map project types to workspace paths
         let workspace_path = match project_type {
-            "test-project" | "test-project-singleton" | "test-project-concurrent" => {
+            "test-project"
+            | "test-project-singleton"
+            | "test-project-concurrent"
+            | "test-project-rename" => {
                 let manifest_dir =
                     std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
                 Path::new(&manifest_dir).join("test-project")

--- a/tests/integration/rename.rs
+++ b/tests/integration/rename.rs
@@ -1,0 +1,106 @@
+//! Tests for the rename tool.
+//!
+//! On a server of their own: renaming reaches across the whole workspace, and the shared
+//! `test-project` server is pointed at another one partway through its tests.
+
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+use test_support::IpcClient;
+
+/// `fn greet` in the test project's `main.rs`, and the call to it above.
+const DEFINITION: (u64, u64) = (13, 3);
+
+#[tokio::test]
+async fn renaming_a_symbol_says_what_it_would_take() -> Result<()> {
+    let mut client = IpcClient::get_or_create("test-project-rename").await?;
+    let main = client.workspace_path().join("src/main.rs");
+    let before = std::fs::read_to_string(&main)?;
+
+    let rename = rename(&mut client, &main, DEFINITION, "welcome").await?;
+
+    assert_eq!(rename["old_name"], "greet", "{rename}");
+    assert_eq!(rename["new_name"], "welcome", "{rename}");
+    assert_eq!(rename["applied"], false, "{rename}");
+    // The definition and the call to it, at least.
+    assert!(
+        rename["summary"]["edits"].as_u64().unwrap_or(0) >= 2,
+        "{rename}"
+    );
+
+    for change in rename["changes"].as_array().unwrap_or(&Vec::new()) {
+        let edits = change["edits"].as_array().cloned().unwrap_or_default();
+        for edit in &edits {
+            // Spelled out, so an edit can be applied to the bytes of the file and checked first.
+            assert_eq!(edit["old_text"], "greet", "{rename}");
+            assert_eq!(edit["new_text"], "welcome", "{rename}");
+            assert!(edit["byte_range"].is_array(), "{rename}");
+        }
+
+        // Last edit first, so applying them one after another needs no arithmetic.
+        let lines: Vec<Value> = edits.iter().map(|edit| edit["line"].clone()).collect();
+        let mut last_first = lines.clone();
+        last_first.sort_by(|a, b| b.as_u64().cmp(&a.as_u64()));
+        assert_eq!(lines, last_first, "{rename}");
+    }
+
+    // Nothing was renamed, only worked out.
+    assert_eq!(std::fs::read_to_string(&main)?, before);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_rename_that_cannot_be_done_says_why() -> Result<()> {
+    let mut client = IpcClient::get_or_create("test-project-rename").await?;
+    let main = client.workspace_path().join("src/main.rs");
+
+    let refused = rename(&mut client, &main, DEFINITION, "1")
+        .await
+        .expect_err("`1` is not a name");
+
+    // rust-analyzer's own words, which are more use than a bare failure.
+    let refused = refused.to_string();
+    assert!(refused.contains('1'), "{refused}");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn renaming_nothing_at_all_says_so() -> Result<()> {
+    let mut client = IpcClient::get_or_create("test-project-rename").await?;
+    let main = client.workspace_path().join("src/main.rs");
+
+    // A blank line, where there is no symbol to rename.
+    let refused = rename(&mut client, &main, (12, 0), "welcome")
+        .await
+        .expect_err("there is nothing on that line to rename");
+
+    assert!(!refused.to_string().is_empty());
+
+    Ok(())
+}
+
+async fn rename(
+    client: &mut IpcClient,
+    file: &std::path::Path,
+    (line, character): (u64, u64),
+    new_name: &str,
+) -> Result<Value> {
+    let response = client
+        .call_tool(
+            "rust_analyzer_rename",
+            json!({
+                "file_path": file.to_str().unwrap(),
+                "line": line,
+                "character": character,
+                "new_name": new_name
+            }),
+        )
+        .await?;
+
+    let text = response["content"][0]["text"]
+        .as_str()
+        .ok_or_else(|| anyhow!("No text in rename response: {response}"))?;
+
+    Ok(serde_json::from_str(text)?)
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,6 +4,13 @@ mod integration {
     mod features;
     mod mcp_server_test;
     mod notifications;
+    mod rename;
     mod shared_test;
     mod shutdown;
+}
+mod unit {
+    mod protocol {
+        mod request_tests;
+        mod tool_tests;
+    }
 }


### PR DESCRIPTION
Fixes #7. **Stacked on #33 → #32 → #31** (last of the chain).

Renaming is the refactoring an LLM is worst at and rust-analyzer is best at: it knows every use of a symbol, including the ones a text search would miss and the ones it would wrongly find.

## `🐛 lsp: Say what rust-analyzer refused to do` (first commit)

An LSP error was logged and then turned into a `null` result, so a request rust-analyzer *declined* was indistinguishable from one that found nothing. For rename that is the difference between "Invalid name `1`: not an identifier" and a rename that appears to have quietly done nothing. The message now reaches the caller as the tool call's error.

Two consequences worth naming:

- `workspace_diagnostics()`'s `Err(_)` fallback was unreachable before (errors never got there) and now runs — which is an improvement, since rust-analyzer has no `workspace/diagnostic` handler at all and that tool used to answer "Unexpected response format" every time.
- Every tool could now fail where it used to return `null` — including on `content modified`, which is rust-analyzer abandoning a request whose analysis was superseded mid-flight (any notification we send can do that). That is not a failure, it is "ask again", so `send_request` now retries it a few times. Tools are more robust than before this PR, not less.

## `✨ mcp: Add a tool for renaming a symbol` (second commit)

`rust_analyzer_rename` takes `file_path`, `line`, `character` and `new_name`, and **changes no files**: a server writing to a checkout takes the decision away from the host that asked and the person behind it, and the file may be open unsaved somewhere this server cannot see. What it does instead is everything needed to apply the edits correctly:

```json
{
  "applied": false,
  "old_name": "greet",
  "new_name": "welcome",
  "position_encoding": "utf-16",
  "summary": { "files_changed": 1, "edits": 3, "file_operations": 0 },
  "changes": [ { "file": "…/src/main.rs", "edits": [
      { "line": 45, "character": 19, "end_line": 45, "end_character": 24,
        "byte_range": [788, 793], "old_text": "greet", "new_text": "welcome" },
      … ] } ],
  "file_operations": [],
  "workspace_edit": { "documentChanges": [ … ] }
}
```

- **Byte ranges**, because the columns rust-analyzer speaks in are UTF-16 code units — neither bytes nor characters. They agree on ASCII lines and stop agreeing at the first `é` (byte offset runs ahead) or emoji (the code-unit count does).
- **`old_text`**, so an edit can be checked before it is made.
- **Edits last-first within each file**, so they can be applied one after another with no offset arithmetic. What rust-analyzer sends is ascending, which is exactly the order that is wrong to apply in.
- **`file_operations`**, because renaming a module renames its file. Asking for that requires declaring `workspace.workspaceEdit.resourceOperations`; without it rust-analyzer refuses the rename outright with "Client does not support rename capability".
- **`workspace_edit`** verbatim for anyone who would rather work it out themselves.

Two things a rename needs that a question about a single file doesn't:

1. **Every open document is brought up to date first.** A rename is worked out from what rust-analyzer holds for each file it touches; a stale one comes back as an edit to a line that has moved. A document whose file has since gone (what a module rename does to it) is closed, so it stops existing as far as rust-analyzer is concerned.
2. **The workspace has to have finished loading, and the tool fails if it hasn't.** A rename worked out halfway through misses the references rust-analyzer hasn't reached, and unlike a diagnostics report there is no way to hand back edits that are only safe to act on in part — whoever asked would have every reason to take them for the whole rename. `prepareRename` runs first too: its answer names the symbol being renamed (that's where `old_name` comes from), and it explains a position with nothing renameable better than the rename does.

## Tests

- `src/position.rs`: the UTF-16-column-to-byte-offset conversion, over `é` (1 unit, 2 bytes), `🦀` (2 units, 4 bytes), a column landing *inside* a character, positions past the end of a line and of the file, and CRLF endings.
- `src/lsp/connection.rs`: an error response reaching the waiter as the message rust-analyzer sent.
- `tests/integration/rename.rs`: a real rename returning `old_name`/`new_name`, every edit's `old_text` being the old name, the edits coming back last-first, and the file on disk being untouched; a rename to `1` failing with rust-analyzer's own words; a position with nothing to rename failing too.

The rename tests run against a server of their own (`test-project-rename`), because `test_workspace_change` points the shared one at a different workspace partway through the suite — which is what made them fail only in a full run until I chased it down.

`cargo test --workspace` (60 unit + 25 integration) and `cargo clippy -- -D warnings` are green.

## Deliberately not here

Applying the edits. If one-call refactoring is wanted, it should be a separate tool with its own name so the host can prompt for it — never folded into this one.