### PR TITLE
👷 ci: Check stacked pull requests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   fmt:


### PR DESCRIPTION
Stacked pull requests target the preceding branch rather than `main`. The workflow's `pull_request.branches: [main]` filter therefore suppresses CI when those pull requests are opened.

GitHub may automatically retarget the next pull request to `main` after its base is merged, but that base change does not emit one of the default `pull_request` activity types that starts this workflow. PR #30 consequently had no workflow run until it was closed and reopened.

Remove the base-branch filter from `pull_request` so every pull request is checked when opened or updated, including intermediate members of a stack. The `push` trigger remains restricted to `main`.

## Test

The change is workflow-only. Opening this pull request against `main` should start the existing lint, build, Linux test, and Windows test jobs.