### PR TITLE
🔖 Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 - 2026-08-22
+
+### Added
+- ✨ Add a tool for renaming a symbol. #7
+- ✨ Run rust-analyzer with the cargo features asked for. #13
+- ✨ Answer the client's pings.
+
+### Changed
+- 🔧 Adopt gimoji's release-plz configuration.
+
+### Documentation
+- 📝 Regenerate the changelog with release-plz's configuration.
+
+### Fixed
+- 🐛 Say what rust-analyzer refused to do.
+- 🐛 Report diagnostics from a check of the file as it is.
+- 🐛 Tell rust-analyzer's requests apart from its answers.
+- 🐛 Never answer JSON-RPC notifications. #21
+
 ## 0.3.1 - 2026-08-21
 
 ### CI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "rust-analyzer-mcp"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["test-project", "test-project-diagnostics"]
 
 [package]
 name = "rust-analyzer-mcp"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "MCP server for rust-analyzer integration"
 authors = ["Zeeshan Ali Khan <zeenix@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release

* `rust-analyzer-mcp`: 0.3.1 -> 0.4.0

Generated with `release-plz update` using the repository's `release-plz.toml`.

### Changelog

#### Added
- ✨ Add a tool for renaming a symbol. #7
- ✨ Run rust-analyzer with the cargo features asked for. #13
- ✨ Answer the client's pings.

#### Changed
- 🔧 Adopt gimoji's release-plz configuration.

#### Documentation
- 📝 Regenerate the changelog with release-plz's configuration.

#### Fixed
- 🐛 Say what rust-analyzer refused to do.
- 🐛 Report diagnostics from a check of the file as it is.
- 🐛 Tell rust-analyzer's requests apart from its answers.
- 🐛 Never answer JSON-RPC notifications. #21

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDyMXsk5tuAhEgUwAnWpqb)_